### PR TITLE
Enable usage of int_to_from_bytes feature

### DIFF
--- a/input-generator/src/main.rs
+++ b/input-generator/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(int_to_from_bytes)]
+
 extern crate rand;
 
 use std::collections::BTreeSet;

--- a/musl-generator/src/main.rs
+++ b/musl-generator/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(int_to_from_bytes)]
+
 extern crate libm;
 extern crate shared;
 

--- a/newlib-generator/src/macros.rs
+++ b/newlib-generator/src/macros.rs
@@ -6,6 +6,7 @@ macro_rules! f32 {
             fs::create_dir_all("math/src")?;
 
             let main = format!("
+#![feature(int_to_from_bytes)]
 #![no_main]
 #![no_std]
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(exact_chunks)]
+#![feature(int_to_from_bytes)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
When compiling the library, rustc complained that the feature int_to_from_bytes had to be enabled. Hence this PR.