### PR TITLE
Update to new to/from_bytes functions

### DIFF
--- a/input-generator/src/main.rs
+++ b/input-generator/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(int_to_from_bytes)]
+
 extern crate rand;
 
 use std::collections::BTreeSet;
@@ -43,7 +45,7 @@ fn f32(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
 
     let mut f = File::create("bin/input/f32")?;
     for i in set {
-        f.write_all(&i.to_bytes())?;
+        f.write_all(&i.to_ne_bytes())?;
     }
 
     Ok(())
@@ -61,8 +63,8 @@ fn f32f32(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bits().to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_bits().to_ne_bytes())?;
     }
 
     Ok(())
@@ -80,8 +82,8 @@ fn f32i16(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_ne_bytes())?;
     }
 
     Ok(())
@@ -100,9 +102,9 @@ fn f32f32f32(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bits().to_bytes())?;
-        f.write_all(&x2.to_bits().to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_bits().to_ne_bytes())?;
+        f.write_all(&x2.to_bits().to_ne_bytes())?;
     }
 
     Ok(())
@@ -123,7 +125,7 @@ fn f64(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
 
     let mut f = File::create("bin/input/f64")?;
     for i in set {
-        f.write_all(&i.to_bytes())?;
+        f.write_all(&i.to_ne_bytes())?;
     }
 
     Ok(())
@@ -141,8 +143,8 @@ fn f64f64(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bits().to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_bits().to_ne_bytes())?;
     }
 
     Ok(())
@@ -161,9 +163,9 @@ fn f64f64f64(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bits().to_bytes())?;
-        f.write_all(&x2.to_bits().to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_bits().to_ne_bytes())?;
+        f.write_all(&x2.to_bits().to_ne_bytes())?;
     }
 
     Ok(())
@@ -181,8 +183,8 @@ fn f64i16(rng: &mut XorShiftRng) -> Result<(), Box<Error>> {
         }
 
         i += 1;
-        f.write_all(&x0.to_bits().to_bytes())?;
-        f.write_all(&x1.to_bytes())?;
+        f.write_all(&x0.to_bits().to_ne_bytes())?;
+        f.write_all(&x1.to_ne_bytes())?;
     }
 
     Ok(())

--- a/musl-generator/src/macros.rs
+++ b/musl-generator/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! f32 {
                     $fun(*x)
                 };
 
-                $fun.write_all(&y.to_bits().to_bytes())?;
+                $fun.write_all(&y.to_bits().to_ne_bytes())?;
             )+
         }
     }};
@@ -40,7 +40,7 @@ macro_rules! f32f32 {
                     $fun(*x0, *x1)
                 };
 
-                $fun.write_all(&y.to_bits().to_bytes())?;
+                $fun.write_all(&y.to_bits().to_ne_bytes())?;
             )+
         }
     }};
@@ -64,7 +64,7 @@ macro_rules! f32f32f32 {
                         $fun(*x0, *x1, *x2)
                     };
 
-                    $fun.write_all(&y.to_bits().to_bytes())?;
+                    $fun.write_all(&y.to_bits().to_ne_bytes())?;
                 )+
             }
     }};
@@ -88,7 +88,7 @@ macro_rules! f32i32 {
                         $fun(*x0, *x1 as i32)
                     };
 
-                    $fun.write_all(&y.to_bits().to_bytes())?;
+                    $fun.write_all(&y.to_bits().to_ne_bytes())?;
                 )+
             }
     }};
@@ -112,7 +112,7 @@ macro_rules! f64 {
                     $fun(*x)
                 };
 
-                $fun.write_all(&y.to_bits().to_bytes())?;
+                $fun.write_all(&y.to_bits().to_ne_bytes())?;
             )+
         }
     }};
@@ -136,7 +136,7 @@ macro_rules! f64f64 {
                     $fun(*x0, *x1)
                 };
 
-                $fun.write_all(&y.to_bits().to_bytes())?;
+                $fun.write_all(&y.to_bits().to_ne_bytes())?;
             )+
         }
     }};
@@ -160,7 +160,7 @@ macro_rules! f64f64f64 {
                         $fun(*x0, *x1, *x2)
                     };
 
-                    $fun.write_all(&y.to_bits().to_bytes())?;
+                    $fun.write_all(&y.to_bits().to_ne_bytes())?;
                 )+
             }
     }};
@@ -184,7 +184,7 @@ macro_rules! f64i32 {
                         $fun(*x0, *x1 as i32)
                     };
 
-                    $fun.write_all(&y.to_bits().to_bytes())?;
+                    $fun.write_all(&y.to_bits().to_ne_bytes())?;
                 )+
             }
     }};

--- a/musl-generator/src/main.rs
+++ b/musl-generator/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(int_to_from_bytes)]
+
 extern crate libm;
 extern crate shared;
 

--- a/newlib-generator/src/macros.rs
+++ b/newlib-generator/src/macros.rs
@@ -61,16 +61,12 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = match {
-                Command::new("qemu-arm")
-                    .arg("math/target/thumbv7em-none-eabi/release/math")
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()
-                } {
-                    Ok(qemu) => qemu,
-                    Err(_) => panic!("missing qemu-arm!")
-                };
+            let mut qemu = Command::new("qemu-arm")
+                .arg("math/target/thumbv7em-none-eabi/release/math")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .map_err(|_| "missing qemu-arm!")?;
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 
@@ -151,16 +147,12 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = match {
-                Command::new("qemu-arm")
-                    .arg("math/target/thumbv7em-none-eabi/release/math")
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()
-                } {
-                    Ok(qemu) => qemu,
-                    Err(_) => panic!("missing qemu-arm!")
-                };
+            let mut qemu = Command::new("qemu-arm")
+                .arg("math/target/thumbv7em-none-eabi/release/math")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .map_err(|_| "missing qemu-arm!")?;
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 
@@ -244,16 +236,12 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = match {
-                Command::new("qemu-arm")
-                    .arg("math/target/thumbv7em-none-eabi/release/math")
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()
-                } {
-                    Ok(qemu) => qemu,
-                    Err(_) => panic!("missing qemu-arm!")
-                };
+            let mut qemu = Command::new("qemu-arm")
+                .arg("math/target/thumbv7em-none-eabi/release/math")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .map_err(|_| "missing qemu-arm!")?;
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 

--- a/newlib-generator/src/macros.rs
+++ b/newlib-generator/src/macros.rs
@@ -6,6 +6,8 @@ macro_rules! f32 {
             fs::create_dir_all("math/src")?;
 
             let main = format!("
+#![feature(int_to_from_bytes)]
+
 #![no_main]
 #![no_std]
 
@@ -33,10 +35,10 @@ fn run() -> Result<(), usize> {{
 
     let mut buf = [0; 4];
     while let Ok(()) = io::Stdin.read_exact(&mut buf) {{
-        let x = f32::from_bits(u32::from_bytes(buf));
+        let x = f32::from_bits(u32::from_ne_bytes(buf));
         let y = unsafe {{ {0}(x) }};
 
-        io::Stdout.write_all(&y.to_bits().to_bytes())?;
+        io::Stdout.write_all(&y.to_bits().to_ne_bytes())?;
     }}
 
     Ok(())
@@ -88,6 +90,8 @@ macro_rules! f32f32 {
             fs::create_dir_all("math/src")?;
 
             let main = format!("
+#![feature(int_to_from_bytes)]
+
 #![no_main]
 #![no_std]
 
@@ -117,14 +121,14 @@ fn run() -> Result<(), usize> {{
     while let Ok(()) = io::Stdin.read_exact(&mut chunk) {{
         let mut buf = [0; 4];
         buf.copy_from_slice(&chunk[..4]);
-        let x0 = f32::from_bits(u32::from_bytes(buf));
+        let x0 = f32::from_bits(u32::from_ne_bytes(buf));
 
         buf.copy_from_slice(&chunk[4..]);
-        let x1 = f32::from_bits(u32::from_bytes(buf));
+        let x1 = f32::from_bits(u32::from_ne_bytes(buf));
 
         let y = unsafe {{ {0}(x0, x1) }};
 
-        io::Stdout.write_all(&y.to_bits().to_bytes())?;
+        io::Stdout.write_all(&y.to_bits().to_ne_bytes())?;
     }}
 
     Ok(())
@@ -176,6 +180,8 @@ macro_rules! f32f32f32 {
             fs::create_dir_all("math/src")?;
 
             let main = format!("
+#![feature(int_to_from_bytes)]
+
 #![no_main]
 #![no_std]
 
@@ -205,17 +211,17 @@ fn run() -> Result<(), usize> {{
     while let Ok(()) = io::Stdin.read_exact(&mut chunk) {{
         let mut buf = [0; 4];
         buf.copy_from_slice(&chunk[..4]);
-        let x0 = f32::from_bits(u32::from_bytes(buf));
+        let x0 = f32::from_bits(u32::from_ne_bytes(buf));
 
         buf.copy_from_slice(&chunk[4..8]);
-        let x1 = f32::from_bits(u32::from_bytes(buf));
+        let x1 = f32::from_bits(u32::from_ne_bytes(buf));
 
         buf.copy_from_slice(&chunk[8..]);
-        let x2 = f32::from_bits(u32::from_bytes(buf));
+        let x2 = f32::from_bits(u32::from_ne_bytes(buf));
 
         let y = unsafe {{ {0}(x0, x1, x2) }};
 
-        io::Stdout.write_all(&y.to_bits().to_bytes())?;
+        io::Stdout.write_all(&y.to_bits().to_ne_bytes())?;
     }}
 
     Ok(())

--- a/newlib-generator/src/macros.rs
+++ b/newlib-generator/src/macros.rs
@@ -59,11 +59,16 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = Command::new("qemu-arm")
-                .arg("math/target/thumbv7em-none-eabi/release/math")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
+            let mut qemu = match {
+                Command::new("qemu-arm")
+                    .arg("math/target/thumbv7em-none-eabi/release/math")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()
+                } {
+                    Ok(qemu) => qemu,
+                    Err(_) => panic!("missing qemu-arm!")
+                };
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 
@@ -142,11 +147,16 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = Command::new("qemu-arm")
-                .arg("math/target/thumbv7em-none-eabi/release/math")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
+            let mut qemu = match {
+                Command::new("qemu-arm")
+                    .arg("math/target/thumbv7em-none-eabi/release/math")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()
+                } {
+                    Ok(qemu) => qemu,
+                    Err(_) => panic!("missing qemu-arm!")
+                };
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 
@@ -228,11 +238,16 @@ pub fn __errno() -> *mut i32 {{
                 .success()
             );
 
-            let mut qemu = Command::new("qemu-arm")
-                .arg("math/target/thumbv7em-none-eabi/release/math")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
+            let mut qemu = match {
+                Command::new("qemu-arm")
+                    .arg("math/target/thumbv7em-none-eabi/release/math")
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()
+                } {
+                    Ok(qemu) => qemu,
+                    Err(_) => panic!("missing qemu-arm!")
+                };
 
             qemu.stdin.as_mut().take().unwrap().write_all(F32)?;
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -12,7 +12,7 @@ lazy_static! {
             .map(|chunk| {
                 let mut buf = [0; 4];
                 buf.copy_from_slice(chunk);
-                f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
+                f32::from_bits(u32::from_le_bytes(buf))
             })
             .collect()
     };
@@ -28,8 +28,8 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[4..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x1))),
+                    f32::from_bits(u32::from_le_bytes(x0)),
+                    f32::from_bits(u32::from_le_bytes(x1)),
                 )
             })
             .collect()
@@ -48,9 +48,9 @@ lazy_static! {
                 x2.copy_from_slice(&chunk[8..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x1))),
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x2))),
+                    f32::from_bits(u32::from_le_bytes(x0)),
+                    f32::from_bits(u32::from_le_bytes(x1)),
+                    f32::from_bits(u32::from_le_bytes(x2)),
                 )
             })
             .collect()
@@ -67,7 +67,7 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[4..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
+                    f32::from_bits(u32::from_le_bytes(x0)),
                     i16::from_le(i16::from_ne_bytes(x1)) as i32,
                 )
             })
@@ -155,7 +155,7 @@ macro_rules! f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
+                        f32::from_bits(u32::from_le_bytes(buf))
                     })
                     .collect::<Vec<_>>();
 
@@ -194,7 +194,7 @@ macro_rules! f32f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
+                        f32::from_bits(u32::from_le_bytes(buf))
                     })
                     .collect::<Vec<_>>();
 
@@ -235,7 +235,7 @@ macro_rules! f32f32f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
+                        f32::from_bits(u32::from_le_bytes(buf))
                     })
                     .collect::<Vec<_>>();
 
@@ -277,7 +277,7 @@ macro_rules! f32i32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
+                        f32::from_bits(u32::from_le_bytes(buf))
                     })
                     .collect::<Vec<_>>();
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(exact_chunks)]
+#![feature(exact_chunks, int_to_from_bytes)]
 
 #[macro_use]
 extern crate lazy_static;
@@ -12,7 +12,7 @@ lazy_static! {
             .map(|chunk| {
                 let mut buf = [0; 4];
                 buf.copy_from_slice(chunk);
-                f32::from_bits(u32::from_le(u32::from_bytes(buf)))
+                f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
             })
             .collect()
     };
@@ -28,8 +28,8 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[4..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_bytes(x0))),
-                    f32::from_bits(u32::from_le(u32::from_bytes(x1))),
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x1))),
                 )
             })
             .collect()
@@ -48,9 +48,9 @@ lazy_static! {
                 x2.copy_from_slice(&chunk[8..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_bytes(x0))),
-                    f32::from_bits(u32::from_le(u32::from_bytes(x1))),
-                    f32::from_bits(u32::from_le(u32::from_bytes(x2))),
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x1))),
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x2))),
                 )
             })
             .collect()
@@ -67,8 +67,8 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[4..]);
 
                 (
-                    f32::from_bits(u32::from_le(u32::from_bytes(x0))),
-                    i16::from_le(i16::from_bytes(x1)) as i32,
+                    f32::from_bits(u32::from_le(u32::from_ne_bytes(x0))),
+                    i16::from_le(i16::from_ne_bytes(x1)) as i32,
                 )
             })
             .collect()
@@ -81,7 +81,7 @@ lazy_static! {
             .map(|chunk| {
                 let mut buf = [0; 8];
                 buf.copy_from_slice(chunk);
-                f64::from_bits(u64::from_le(u64::from_bytes(buf)))
+                f64::from_bits(u64::from_le(u64::from_ne_bytes(buf)))
             })
             .collect()
     };
@@ -97,8 +97,8 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[8..]);
 
                 (
-                    f64::from_bits(u64::from_le(u64::from_bytes(x0))),
-                    f64::from_bits(u64::from_le(u64::from_bytes(x1))),
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x0))),
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x1))),
                 )
             })
             .collect()
@@ -117,9 +117,9 @@ lazy_static! {
                 x2.copy_from_slice(&chunk[16..]);
 
                 (
-                    f64::from_bits(u64::from_le(u64::from_bytes(x0))),
-                    f64::from_bits(u64::from_le(u64::from_bytes(x1))),
-                    f64::from_bits(u64::from_le(u64::from_bytes(x2))),
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x0))),
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x1))),
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x2))),
                 )
             })
             .collect()
@@ -136,8 +136,8 @@ lazy_static! {
                 x1.copy_from_slice(&chunk[8..]);
 
                 (
-                    f64::from_bits(u64::from_le(u64::from_bytes(x0))),
-                    i16::from_le(i16::from_bytes(x1)) as i32,
+                    f64::from_bits(u64::from_le(u64::from_ne_bytes(x0))),
+                    i16::from_le(i16::from_ne_bytes(x1)) as i32,
                 )
             })
             .collect()
@@ -155,7 +155,7 @@ macro_rules! f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_bytes(buf)))
+                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -194,7 +194,7 @@ macro_rules! f32f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_bytes(buf)))
+                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -235,7 +235,7 @@ macro_rules! f32f32f32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_bytes(buf)))
+                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -277,7 +277,7 @@ macro_rules! f32i32 {
                     .map(|chunk| {
                         let mut buf = [0; 4];
                         buf.copy_from_slice(chunk);
-                        f32::from_bits(u32::from_le(u32::from_bytes(buf)))
+                        f32::from_bits(u32::from_le(u32::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -318,7 +318,7 @@ macro_rules! f64 {
                     .map(|chunk| {
                         let mut buf = [0; 8];
                         buf.copy_from_slice(chunk);
-                        f64::from_bits(u64::from_le(u64::from_bytes(buf)))
+                        f64::from_bits(u64::from_le(u64::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -357,7 +357,7 @@ macro_rules! f64f64 {
                     .map(|chunk| {
                         let mut buf = [0; 8];
                         buf.copy_from_slice(chunk);
-                        f64::from_bits(u64::from_le(u64::from_bytes(buf)))
+                        f64::from_bits(u64::from_le(u64::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -398,7 +398,7 @@ macro_rules! f64f64f64 {
                     .map(|chunk| {
                         let mut buf = [0; 8];
                         buf.copy_from_slice(chunk);
-                        f64::from_bits(u64::from_le(u64::from_bytes(buf)))
+                        f64::from_bits(u64::from_le(u64::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 
@@ -440,7 +440,7 @@ macro_rules! f64i32 {
                     .map(|chunk| {
                         let mut buf = [0; 8];
                         buf.copy_from_slice(chunk);
-                        f64::from_bits(u64::from_le(u64::from_bytes(buf)))
+                        f64::from_bits(u64::from_le(u64::from_ne_bytes(buf)))
                     })
                     .collect::<Vec<_>>();
 


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/pull/51919, `to/from_bytes` has been renamed to `to/from_ne_bytes`. This pull request renames all occurrences to be in line with that.

Additionally, I changed the newlib generator to give a helpful error message when it's missing `qemu-arm`.