### PR TITLE
Fixed uint overflow in floorf for negative exponents

### DIFF
--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -12,7 +12,7 @@ pub fn floorf(x: f32) -> f32 {
         }
     }
     let mut ui = x.to_bits();
-    let e = (((ui >> 23) & 0xff) - 0x7f) as i32;
+    let e = (((ui >> 23) as i32) & 0xff) - 0x7f;
 
     if e >= 23 {
         return x;

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -37,3 +37,11 @@ pub fn floorf(x: f32) -> f32 {
     }
     return f32::from_bits(ui);
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn no_overflow() {
+        assert_eq!(super::floorf(0.5), 0.0);
+    }
+}


### PR DESCRIPTION
`floorf` has a bug in extracting the exponent from bits, where intermediate calculation results are `u32`, but can go negative for negative exponents.

The test case is very simple: calling `libm::floorf(0.5)` in debug mode will panic with the following message:

`'attempt to subtract with overflow', <path>/libm/src/math/floorf.rs:6:13`

I took a quick look at other similar functions and couldn't find problems. It would be nice to run tests in debug mode to check if there are any other places that cause similar underflows.