### PR TITLE
Make module path compatible with Rust 1.31.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod math;
 
 use core::{f32, f64};
 
-pub use math::*;
+pub use self::math::*;
 
 /// Approximate equality with 1 ULP of tolerance
 #[doc(hidden)]


### PR DESCRIPTION
This makes this crate compile on Rust 1.31.0. See #182 