### PR TITLE
Prepare release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ...
 
+## [v0.1.4] - 2019-06-12
+
+### Fixed
+- Restored compatibility with Rust 1.31.0
+
 ## [v0.1.3] - 2019-05-14
 
 ### Added
@@ -85,7 +90,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/libm/compare/0.1.3...HEAD
+[Unreleased]: https://github.com/japaric/libm/compare/v0.1.4...HEAD
+[v0.1.4]: https://github.com/japaric/libm/compare/0.1.3...v0.1.4
 [v0.1.3]: https://github.com/japaric/libm/compare/v0.1.2...0.1.3
 [v0.1.2]: https://github.com/japaric/libm/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/japaric/libm/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+...
+
+## [v0.1.3] - 2019-05-14
+
 ### Added
 
 - minf
@@ -81,6 +85,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/libm/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/japaric/libm/compare/0.1.3...HEAD
+[v0.1.3]: https://github.com/japaric/libm/compare/v0.1.2...0.1.3
 [v0.1.2]: https://github.com/japaric/libm/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/japaric/libm/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["libm", "math"]
 license = "MIT OR Apache-2.0"
 name = "libm"
 repository = "https://github.com/rust-lang-nursery/libm"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
I added a ChangeLog entry for release 0.1.3 which did not have one. The entry does not contain the fixes that were included in the last release but this can be updated in the future.

The only important thing would be naming the tag `v0.1.4` so that the links match.
I assume last release tag being named solely `0.1.3` was a mishap but let me know otherwise.

This release includes the fix for #182 