### PR TITLE
Fixed rounding to negative zero

### DIFF
--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -36,7 +36,12 @@ pub fn round(mut x: f64) -> f64 {
     }
 }
 
-#[test]
-fn negative_zero() {
-    assert_eq!(round(-0.0_f64).to_bits(), (-0.0_f64).to_bits());
+#[cfg(test)]
+mod tests {
+    use super::round;
+
+    #[test]
+    fn negative_zero() {
+        assert_eq!(round(-0.0_f64).to_bits(), (-0.0_f64).to_bits());
+    }
 }

--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -5,20 +5,20 @@ const TOINT: f64 = 1.0 / f64::EPSILON;
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn round(mut x: f64) -> f64 {
-    let (f, i) = (x, x.to_bits());
+    let i = x.to_bits();
     let e: u64 = i >> 52 & 0x7ff;
     let mut y: f64;
 
     if e >= 0x3ff + 52 {
         return x;
     }
-    if i >> 63 != 0 {
-        x = -x;
-    }
     if e < 0x3ff - 1 {
         // raise inexact if x!=0
         force_eval!(x + TOINT);
-        return 0.0 * f;
+        return 0.0 * x;
+    }
+    if i >> 63 != 0 {
+        x = -x;
     }
     y = x + TOINT - TOINT - x;
     if y > 0.5 {
@@ -34,4 +34,9 @@ pub fn round(mut x: f64) -> f64 {
     } else {
         y
     }
+}
+
+#[test]
+fn negative_zero() {
+    assert_eq!(round(-0.0_f64).to_bits(), (-0.0_f64).to_bits());
 }

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -12,12 +12,12 @@ pub fn roundf(mut x: f32) -> f32 {
     if e >= 0x7f + 23 {
         return x;
     }
-    if i >> 31 != 0 {
-        x = -x;
-    }
     if e < 0x7f - 1 {
         force_eval!(x + TOINT);
         return 0.0 * x;
+    }
+    if i >> 31 != 0 {
+        x = -x;
     }
     y = x + TOINT - TOINT - x;
     if y > 0.5f32 {
@@ -32,4 +32,9 @@ pub fn roundf(mut x: f32) -> f32 {
     } else {
         y
     }
+}
+
+#[test]
+fn negative_zero() {
+    assert_eq!(roundf(-0.0_f32).to_bits(), (-0.0_f32).to_bits());
 }

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -34,7 +34,12 @@ pub fn roundf(mut x: f32) -> f32 {
     }
 }
 
-#[test]
-fn negative_zero() {
-    assert_eq!(roundf(-0.0_f32).to_bits(), (-0.0_f32).to_bits());
+#[cfg(test)]
+mod tests {
+    use super::roundf;
+
+    #[test]
+    fn negative_zero() {
+        assert_eq!(roundf(-0.0_f32).to_bits(), (-0.0_f32).to_bits());
+    }
 }


### PR DESCRIPTION
Rounding of negative values near zero should return negative zero.

Discovered thanks to test suite by @Schultzer