### PR TITLE
[WIP] Provide a cdylib with the libm C ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ checked = []
 [workspace]
 members = [
   "crates/compiler-builtins-smoke-test",
-  "crates/libm-cdylib",
   "crates/libm-bench",
+  "crates/libm-cdylib",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ checked = []
 [workspace]
 members = [
   "crates/compiler-builtins-smoke-test",
+  "crates/libm-cdylib",
   "crates/libm-bench",
 ]
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,11 @@ jobs:
           TARGET: powerpc64-unknown-linux-gnu
         powerpc64le:
           TARGET: powerpc64le-unknown-linux-gnu
-        x86_64:
+        x86_64_stable:
           TARGET: x86_64-unknown-linux-gnu
+        x86_64_nightly:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: nightly
 
   - job: OSX
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,23 @@ jobs:
         x86_64:
           TARGET: x86_64-unknown-linux-gnu
 
+  - job: OSX
+    pool:
+      vmImage: macos-10.13
+    steps:
+      - template: ci/azure-install-rust.yml
+      - bash: |
+          rustup target add $TARGET
+          sh ./ci/run.sh $TARGET
+    strategy:
+      matrix:
+        i686-apple-darwin:
+          TARGET: i686-apple-darwin
+          TOOLCHAIN: nightly
+        x86_64-apple-darwin:
+          TARGET: x86_64-apple-darwin
+          TOOLCHAIN: nightly
+
   - job: wasm
     pool:
       vmImage: ubuntu-16.04

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
 
 set -ex
+
 TARGET=$1
+
+export RUST_BACKTRACE=1
+export RUST_TEST_THREADS=1
 
 CMD="cargo test --all --no-default-features --target $TARGET"
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -24,10 +24,12 @@ fi
 $CMD --features "stable checked"
 $CMD --release --features  "stable checked ${TEST_MUSL}"
 
-if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "x86_64-apple-darwin" ]; then
-    (
-        cd crates/libm-cdylib
-        cargo test
-        cargo test --release
-    )
+if rustc --version | grep "nightly" ; then
+    if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "x86_64-apple-darwin" ]; then
+        (
+            cd crates/libm-cdylib
+            cargo test
+            cargo test --release
+        )
+    fi
 fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,11 +8,17 @@ CMD="cargo test --all --no-default-features --target $TARGET"
 $CMD
 $CMD --release
 
-$CMD --features 'stable'
-$CMD --release --features 'stable'
+$CMD --features "stable"
+$CMD --release --features "stable"
 
-$CMD --features 'stable checked musl-reference-tests'
-$CMD --release --features  'stable checked musl-reference-tests'
+TEST_MUSL="musl-reference-tests"
+if [ "$TARGET" = "x86_64-apple-darwin" ] || [ "$TARGET" = "i686-apple-darwin" ] ; then
+    # FIXME: disable musl-reference-tests on OSX
+    export TEST_MUSL=""
+fi
+
+$CMD --features "stable checked"
+$CMD --release --features  "stable checked ${TEST_MUSL}"
 
 if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "x86_64-apple-darwin" ]; then
     (

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,3 +13,11 @@ $CMD --release --features 'stable'
 
 $CMD --features 'stable checked musl-reference-tests'
 $CMD --release --features  'stable checked musl-reference-tests'
+
+if [ "$TARGET" = "x86_64-unknown-linux-gnu" ] || [ "${TARGET}" = "x86_64-apple-darwin" ]; then
+    (
+        cd crates/libm-cdylib
+        cargo test
+        cargo test --release
+    )
+fi

--- a/crates/libm-cdylib/Cargo.toml
+++ b/crates/libm-cdylib/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "libm-cdylib"
+version = "0.1.0"
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
+
+[features]
+default = ['stable']
+stable = []
+
+# Used checked array indexing instead of unchecked array indexing in this
+# library.
+checked = []
+
+[lib]
+name = "libm"
+crate-type = ["cdylib"]
+
+[dev-dependencies]
+paste = "0.1.5"

--- a/crates/libm-cdylib/build.rs
+++ b/crates/libm-cdylib/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let profile = env::var("PROFILE").unwrap_or(String::new());
+    if profile == "release" {
+        println!("cargo:rustc-cfg=release_profile");
+    }
+}

--- a/crates/libm-cdylib/build.rs
+++ b/crates/libm-cdylib/build.rs
@@ -5,4 +5,13 @@ fn main() {
     if profile == "release" {
         println!("cargo:rustc-cfg=release_profile");
     }
+    let nightly = {
+        let mut cmd = std::process::Command::new("rustc");
+        cmd.arg("--version");
+        let output = String::from_utf8(cmd.output().unwrap().stdout).unwrap();
+        output.contains("nightly")
+    };
+    if nightly {
+        println!("cargo:rustc-cfg=unstable_rust");
+    }
 }

--- a/crates/libm-cdylib/src/lib.rs
+++ b/crates/libm-cdylib/src/lib.rs
@@ -1,3 +1,10 @@
+#![cfg(
+    // The tests are only enabled on x86 32/64-bit linux/macos:
+    all(unstable_rust,
+        any(target_os = "linux", target_os = "macos"),
+        any(target_arch = "x86", target_arch = "x86_64")
+    )
+)]
 #![allow(dead_code)]
 #![cfg_attr(not(test), feature(core_intrinsics, lang_items))]
 #![cfg_attr(not(test), no_std)]

--- a/crates/libm-cdylib/src/lib.rs
+++ b/crates/libm-cdylib/src/lib.rs
@@ -1,0 +1,153 @@
+#![allow(dead_code)]
+#![cfg_attr(not(test), feature(core_intrinsics, lang_items))]
+#![cfg_attr(not(test), no_std)]
+
+#[path = "../../../src/math/mod.rs"]
+mod libm;
+
+#[macro_use]
+mod macros;
+
+#[cfg(test)]
+mod test_utils;
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::intrinsics::abort() }
+}
+
+#[cfg(not(test))]
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+// All functions to be exported by the C ABI.
+// Includes a test input/output pair for testing.
+// The test output will be used to override the
+// result of the function, and the test input
+// is used to call the overriden function from C.
+// This is needed to make sure that we are linking
+// against this libm during testing, and not the
+// system's libm.
+//
+//
+// FIXME: missing symbols: _memcpy, _memset, etc.
+export! {
+    fn acos(x: f64) -> f64: (42.) -> 42.;
+    fn acosf(x: f32) -> f32: (42.) -> 42.;
+    fn acosh(x: f64) -> f64: (42.) -> 42.;
+    fn acoshf(x: f32) -> f32: (42.) -> 42.;
+    fn asin(x: f64) -> f64: (42.) -> 42.;
+    fn asinf(x: f32) -> f32: (42.) -> 42.;
+    fn asinh(x: f64) -> f64: (42.) -> 42.;
+    fn asinhf(x: f32) -> f32: (42.) -> 42.;
+    // fn atan(x: f64) -> f64: (42.) -> 42.;
+    fn atanf(x: f32) -> f32: (42.) -> 42.;
+    fn atanh(x: f64) -> f64: (42.) -> 42.;
+    fn atanhf(x: f32) -> f32: (42.) -> 42.;
+    fn cbrt(x: f64) -> f64: (42.) -> 42.;
+    fn cbrtf(x: f32) -> f32: (42.) -> 42.;
+    fn ceil(x: f64) -> f64: (42.) -> 42.;
+    fn ceilf(x: f32) -> f32: (42.) -> 42.;
+    fn copysign(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn copysignf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    //fn cos(x: f64) -> f64: (42.) -> 42.;
+    //fn cosf(x: f32) -> f32: (42.) -> 42.;
+    fn cosh(x: f64) -> f64: (42.) -> 42.;
+    fn coshf(x: f32) -> f32: (42.) -> 42.;
+    fn erf(x: f64) -> f64: (42.) -> 42.;
+    fn erfc(x: f64) -> f64: (42.) -> 42.;
+    fn erff(x: f32) -> f32: (42.) -> 42.;
+    fn erfcf(x: f32) -> f32: (42.) -> 42.;
+    fn exp(x: f64) -> f64: (42.) -> 42.;
+    fn expf(x: f32) -> f32: (42.) -> 42.;
+    // FIXME: not in C:
+    // fn exp10(x: f64) -> f64: (42.) -> 42.;
+    // fn exp10f(x: f32) -> f32: (42.) -> 42.;
+    fn exp2(x: f64) -> f64: (42.) -> 42.;
+    fn exp2f(x: f32) -> f32: (42.) -> 42.;
+    fn expm1(x: f64) -> f64: (42.) -> 42.;
+    fn expm1f(x: f32) -> f32: (42.) -> 42.;
+    fn fabs(x: f64) -> f64: (42.) -> 42.;
+    fn fabsf(x: f32) -> f32: (42.) -> 42.;
+    fn fdim(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn fdimf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    fn floor(x: f64) -> f64: (42.) -> 42.;
+    fn floorf(x: f32) -> f32: (42.) -> 42.;
+    fn fma(x: f64, y: f64, z: f64) -> f64: (42., 42., 42.) -> 42.;
+    fn fmaf(x: f32, y: f32, z: f32) -> f32: (42., 42., 42.) -> 42.;
+    fn fmax(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn fmaxf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    fn fmin(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn fminf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    fn fmod(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn fmodf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+
+    // different ABI than in C
+    // fn frexp(x: f64) -> (f64, i32): (42.) -> (42., 42);
+    // fn frexpf(x: f32) -> (f32, i32): (42.) -> (42., 42);
+
+    fn hypot(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn hypotf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    fn ilogb(x: f64) -> i32: (42.) -> 42;
+    fn ilogbf(x: f32) -> i32: (42.) -> 42;
+
+    // FIXME: fail to link:
+    // fn j0(x: f64) -> f64: (42.) -> 42.;
+    // fn j0f(x: f32) -> f32: (42.) -> 42.;
+    // fn j1(x: f64) -> f64: (42.) -> 42.;
+    // fn j1f(x: f32) -> f32: (42.) -> 42.;
+    // fn jn(n: i32, x: f64) -> f64: (42, 42.) -> 42.;
+    // fn jnf(n: i32, x: f32) -> f32: (42, 42.) -> 42.;
+
+    fn ldexp(x: f64, n: i32) -> f64: (42, 42.) -> 42.;
+    fn ldexpf(x: f32, n: i32) -> f32: (42, 42.) -> 42.;
+    fn lgamma(x: f64) -> f64: (42.) -> 42.;
+    fn lgammaf(x: f32) -> f32: (42.) -> 42.;
+
+    // different ABI
+    // fn lgamma_r(x: f64) -> (f64, i32): (42.) -> (42., 42);
+    // fn lgammaf_r(x: f32) -> (f32, i32): (42.) -> (42., 42);
+
+    fn log(x: f64) -> f64: (42.) -> 42.;
+    fn logf(x: f32) -> f32: (42.) -> 42.;
+    fn log10(x: f64) -> f64: (42.) -> 42.;
+    fn log10f(x: f32) -> f32: (42.) -> 42.;
+    fn log1p(x: f64) -> f64: (42.) -> 42.;
+    fn log1pf(x: f32) -> f32: (42.) -> 42.;
+    fn log2(x: f64) -> f64: (42.) -> 42.;
+    fn log2f(x: f32) -> f32: (42.) -> 42.;
+    fn pow(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
+    fn powf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    // fn modf(x: f64) -> (f64, f64): (42.) -> (42., 42.);
+    // fn modff(x: f32) -> (f32, f32): (42.) -> (42., 42.);
+
+    // different ABI
+    // remquo
+    // remquof
+
+    fn round(x: f64) -> f64: (42.) -> 42.;
+    fn roundf(x: f32) -> f32: (42.) -> 42.;
+    fn scalbn(x: f64, n: i32) -> f64: (42., 42) -> 42.;
+    fn scalbnf(x: f32, n: i32) -> f32: (42., 42) -> 42.;
+
+    // different ABI
+    // fn sincos
+    // fn sincosf
+
+    // fn sin(x: f64) -> f64: (42.) -> 42.;
+    // fn sinf(x: f32) -> f32: (42.) -> 42.;
+
+    fn sinh(x: f64) -> f64: (42.) -> 42.;
+    fn sinhf(x: f32) -> f32: (42.) -> 42.;
+    fn sqrt(x: f64) -> f64: (42.) -> 42.;
+    fn sqrtf(x: f32) -> f32: (42.) -> 42.;
+    // fn tan(x: f64) -> f64: (42.) -> 42.;
+    // fn tanf(x: f32) -> f32: (42.) -> 42.;
+    fn tanh(x: f64) -> f64: (42.) -> 42.;
+    fn tanhf(x: f32) -> f32: (42.) -> 42.;
+    // fn tgamma(x: f64) -> f64: (42.) -> 42.;
+    // fn tgammaf(x: f32) -> f32: (42.) -> 42.;
+    fn trunc(x: f64) -> f64: (42.) -> 42.;
+    fn truncf(x: f32) -> f32: (42.) -> 42.;
+}

--- a/crates/libm-cdylib/src/lib.rs
+++ b/crates/libm-cdylib/src/lib.rs
@@ -14,24 +14,22 @@ mod test_utils;
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // TODO: just call libc::abort - fails to link
+    // unsafe { libc::abort() }
     unsafe { core::intrinsics::abort() }
 }
 
+// TODO: there has to be a way to avoid this
 #[cfg(not(test))]
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
-// All functions to be exported by the C ABI.
-// Includes a test input/output pair for testing.
-// The test output will be used to override the
-// result of the function, and the test input
-// is used to call the overriden function from C.
-// This is needed to make sure that we are linking
-// against this libm during testing, and not the
-// system's libm.
+// This macro exports the functions that are part of the C ABI.
 //
-//
-// FIXME: missing symbols: _memcpy, _memset, etc.
+// It generates tests that replace the implementation of the
+// function with a specific value, that then is used to check
+// that the library is properly linked.
+
 export! {
     fn acos(x: f64) -> f64: (42.) -> 42.;
     fn acosf(x: f32) -> f32: (42.) -> 42.;
@@ -41,6 +39,7 @@ export! {
     fn asinf(x: f32) -> f32: (42.) -> 42.;
     fn asinh(x: f64) -> f64: (42.) -> 42.;
     fn asinhf(x: f32) -> f32: (42.) -> 42.;
+    // FIXME: fails to link. Missing symbol: _memcpy
     // fn atan(x: f64) -> f64: (42.) -> 42.;
     fn atanf(x: f32) -> f32: (42.) -> 42.;
     fn atanh(x: f64) -> f64: (42.) -> 42.;
@@ -51,6 +50,7 @@ export! {
     fn ceilf(x: f32) -> f32: (42.) -> 42.;
     fn copysign(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
     fn copysignf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+    // FIXME: fails to link. Missing symbols
     //fn cos(x: f64) -> f64: (42.) -> 42.;
     //fn cosf(x: f32) -> f32: (42.) -> 42.;
     fn cosh(x: f64) -> f64: (42.) -> 42.;
@@ -83,7 +83,7 @@ export! {
     fn fmod(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
     fn fmodf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
 
-    // different ABI than in C
+    // TODO: different ABI than in C - need a more elaborate wrapper
     // fn frexp(x: f64) -> (f64, i32): (42.) -> (42., 42);
     // fn frexpf(x: f32) -> (f32, i32): (42.) -> (42., 42);
 
@@ -92,7 +92,7 @@ export! {
     fn ilogb(x: f64) -> i32: (42.) -> 42;
     fn ilogbf(x: f32) -> i32: (42.) -> 42;
 
-    // FIXME: fail to link:
+    // FIXME: fails to link. Missing symbols
     // fn j0(x: f64) -> f64: (42.) -> 42.;
     // fn j0f(x: f32) -> f32: (42.) -> 42.;
     // fn j1(x: f64) -> f64: (42.) -> 42.;
@@ -105,7 +105,7 @@ export! {
     fn lgamma(x: f64) -> f64: (42.) -> 42.;
     fn lgammaf(x: f32) -> f32: (42.) -> 42.;
 
-    // different ABI
+    // TODO: different ABI than in C - need a more elaborate wrapper
     // fn lgamma_r(x: f64) -> (f64, i32): (42.) -> (42., 42);
     // fn lgammaf_r(x: f32) -> (f32, i32): (42.) -> (42., 42);
 
@@ -119,10 +119,10 @@ export! {
     fn log2f(x: f32) -> f32: (42.) -> 42.;
     fn pow(x: f64, y: f64) -> f64: (42., 42.) -> 42.;
     fn powf(x: f32, y: f32) -> f32: (42., 42.) -> 42.;
+
+    // FIXME: different ABI than in C - need a more elaborate wrapper
     // fn modf(x: f64) -> (f64, f64): (42.) -> (42., 42.);
     // fn modff(x: f32) -> (f32, f32): (42.) -> (42., 42.);
-
-    // different ABI
     // remquo
     // remquof
 
@@ -131,10 +131,11 @@ export! {
     fn scalbn(x: f64, n: i32) -> f64: (42., 42) -> 42.;
     fn scalbnf(x: f32, n: i32) -> f32: (42., 42) -> 42.;
 
-    // different ABI
+    // FIXME: different ABI than in C - need a more elaborate wrapper
     // fn sincos
     // fn sincosf
 
+    // FIXME: missing symbols - fails to link
     // fn sin(x: f64) -> f64: (42.) -> 42.;
     // fn sinf(x: f32) -> f32: (42.) -> 42.;
 
@@ -142,10 +143,12 @@ export! {
     fn sinhf(x: f32) -> f32: (42.) -> 42.;
     fn sqrt(x: f64) -> f64: (42.) -> 42.;
     fn sqrtf(x: f32) -> f32: (42.) -> 42.;
+    // FIXME: missing symbols - fails to link
     // fn tan(x: f64) -> f64: (42.) -> 42.;
     // fn tanf(x: f32) -> f32: (42.) -> 42.;
     fn tanh(x: f64) -> f64: (42.) -> 42.;
     fn tanhf(x: f32) -> f32: (42.) -> 42.;
+    // FIXME: missing symbols - fails to link
     // fn tgamma(x: f64) -> f64: (42.) -> 42.;
     // fn tgammaf(x: f32) -> f32: (42.) -> 42.;
     fn trunc(x: f64) -> f64: (42.) -> 42.;

--- a/crates/libm-cdylib/src/macros.rs
+++ b/crates/libm-cdylib/src/macros.rs
@@ -25,6 +25,9 @@ macro_rules! export {
             fn [<$id _link_test>]() {
                 use crate::test_utils::*;
 
+                // This re-compiles the dynamic library:
+                compile_cdylib();
+
                 // Generate a small C program that calls the C API from
                 // <math.h>. This program prints the result into an appropriate
                 // type, that is then printed to stdout.
@@ -55,10 +58,9 @@ macro_rules! export {
 
                 // We now compile the C program into an executable, make sure
                 // that the libm-cdylib has been generated (and generate it if
-                // it isn't), and then we run the program, override the libm
-                // dynamically, and verify the result.
+                // it isn't), and then we run the program, override the libm,
+                // and verify the result.
                 compile_file(&src_path, &bin_path);
-                compile_cdylib();
                 check(&bin_path, $test_ret as $ret_ty)
             }
         }

--- a/crates/libm-cdylib/src/macros.rs
+++ b/crates/libm-cdylib/src/macros.rs
@@ -51,7 +51,6 @@ macro_rules! export {
                 );
 
                 let target_dir = target_dir();
-                eprintln!("target dir: {}", target_dir.display());
                 let src_path = target_dir.clone().join(format!("{}.c", stringify!($id)));
                 let bin_path = target_dir.clone().join(format!("{}", stringify!($id)));
                 write_to_file(&src_path, &ctest);

--- a/crates/libm-cdylib/src/macros.rs
+++ b/crates/libm-cdylib/src/macros.rs
@@ -1,0 +1,55 @@
+macro_rules! export {
+    (fn $id:ident ($($arg:ident : $arg_ty:ty),* ) -> $ret_ty:ty:
+       ($($test_arg:expr),*) -> $test_ret:expr;) => {
+        #[no_mangle]
+        pub extern "C" fn $id($($arg: $arg_ty),*) -> $ret_ty {
+            #[cfg(link_test)] {
+                let _ = libm::$id($($arg),*);
+                $test_ret as _
+            }
+            #[cfg(not(link_test))] {
+                libm::$id($($arg),*)
+            }
+        }
+
+        #[cfg(test)]
+        paste::item! {
+            #[test]
+            fn [<$id _test>]() {
+                use crate::test_utils::*;
+                let (cret_t, c_format_s) = ctype_and_cformat(stringify!($ret_ty));
+                let ctest = format!(
+                    r#"
+                        #include <math.h>
+                        #include <stdio.h>
+                        #include <stdint.h>
+                        int main() {{
+                            {cret_t} result = {id}({input});
+                            fprintf(stdout, "{c_format_s}", result);
+                            return 0;
+                        }}
+                    "#,
+                    id = stringify!($id),
+                    input = [$(stringify!($test_arg)),*].join(","),
+                    cret_t = cret_t,
+                    c_format_s = c_format_s
+                );
+
+                let src = &format!("../../target/{}.c", stringify!($id));
+                let bin = &format!("../../target/{}", stringify!($id));
+                let src_path = std::path::Path::new(src);
+                let bin_path = std::path::Path::new(bin);
+                write_to_file(&src_path, &ctest);
+                compile_file(&src_path, &bin_path);
+                compile_lib();
+                check(&bin_path, $test_ret as $ret_ty)
+            }
+        }
+    };
+     ($(fn $id:ident ($($arg:ident : $arg_ty:ty),* ) -> $ret_ty:ty:
+        ($($test_arg:expr),*) -> $test_ret:expr;)*) => {
+        $(
+            export! { fn $id ($($arg : $arg_ty),* ) -> $ret_ty: ($($test_arg),*) -> $test_ret; }
+        )*
+    }
+}

--- a/crates/libm-cdylib/src/macros.rs
+++ b/crates/libm-cdylib/src/macros.rs
@@ -47,10 +47,10 @@ macro_rules! export {
                     c_format_s = c_format_s
                 );
 
-                let src = &format!("../../target/{}.c", stringify!($id));
-                let bin = &format!("../../target/{}", stringify!($id));
-                let src_path = std::path::Path::new(src);
-                let bin_path = std::path::Path::new(bin);
+                let target_dir = target_dir();
+                eprintln!("target dir: {}", target_dir.display());
+                let src_path = target_dir.clone().join(format!("{}.c", stringify!($id)));
+                let bin_path = target_dir.clone().join(format!("{}", stringify!($id)));
                 write_to_file(&src_path, &ctest);
 
                 // We now compile the C program into an executable, make sure

--- a/crates/libm-cdylib/src/test_utils.rs
+++ b/crates/libm-cdylib/src/test_utils.rs
@@ -48,17 +48,8 @@ pub(crate) fn compile_file(src_path: &Path, bin_path: &Path) {
 
     // Link our libm
     let lib_path = cdylib_dir();
-    {
-        let mut ls = process::Command::new("ls");
-        ls.arg(lib_path.clone());
-        let output = ls.output().unwrap();
-        let output = String::from_utf8(output.stdout).unwrap();
-        println!("ls\n{}]n", output);
-    }
     cmd.arg(format!("-L{}", lib_path.display()));
     cmd.arg("-llibm");
-
-    eprintln!("compile cmd: {:?}", cmd);
 
     handle_err(
         &format!("compile file: {}", src_path.display()),
@@ -98,8 +89,7 @@ where
 
 pub(crate) fn handle_err(step: &str, output: &process::Output) {
     if !output.status.success() {
-        eprintln!("{}", format_output(step, output));
-        panic!();
+        panic!("{}", format_output(step, output));
     }
 }
 

--- a/crates/libm-cdylib/src/test_utils.rs
+++ b/crates/libm-cdylib/src/test_utils.rs
@@ -1,0 +1,108 @@
+use std::{fs, io, path::Path, process};
+
+pub(crate) fn write_to_file(path: &Path, content: &str) {
+    use io::Write;
+    let mut file = fs::File::create(&path).unwrap();
+    write!(file, "{}", content).unwrap();
+}
+
+pub(crate) fn compile_lib() {
+    let mut cmd = process::Command::new("cargo");
+    cmd.arg("build");
+    if cfg!(release_profile) {
+        cmd.arg("--release");
+    }
+    cmd.env("RUSTFLAGS", "--cfg=link_test");
+    handle_err("lib_build", &cmd.output().unwrap());
+}
+
+pub(crate) fn compile_file(src_path: &Path, bin_path: &Path) {
+    let mut cmd = process::Command::new("CC");
+    cmd.arg("-fno-builtin")
+        .arg("-o")
+        .arg(bin_path)
+        .arg(src_path);
+    handle_err(
+        &format!("compile file: {}", src_path.display()),
+        &cmd.output().unwrap(),
+    );
+}
+
+pub(crate) fn check<T>(path: &Path, expected: T)
+where
+    T: PartialEq + std::fmt::Debug + std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    let mut cmd = process::Command::new(path);
+
+    let libm_path = format!(
+        "../../target/{}/liblibm.",
+        if cfg!(release_profile) {
+            "release"
+        } else {
+            "debug"
+        },
+    );
+
+    // Replace libm at runtime
+    if cfg!(target_os = "macos") {
+        // cmd.env("DYLD_PRINT_LIBRARIES", "1");
+        // cmd.env("X", "1");
+        cmd.env("DYLD_FORCE_FLAT_NAMESPACE", "1");
+        cmd.env(
+            "DYLD_INSERT_LIBRARIES",
+            format!("{}.{}", libm_path, "dylib"),
+        );
+    } else if cfg!(target_os = "linux") {
+        cmd.env("LD_PRELOAD", format!("{}.{}", libm_path, "so"))
+    }
+    let output = cmd.output().unwrap();
+    handle_err(&format!("run file: {}", path.display()), &output);
+    let result = String::from_utf8(output.stdout.clone())
+        .unwrap()
+        .parse::<T>();
+
+    if result.is_err() {
+        panic!(format_output("check (parse failure)", &output));
+    }
+    let result = result.unwrap();
+    assert_eq!(result, expected, "{}", format_output("check", &output));
+}
+
+pub(crate) fn handle_err(step: &str, output: &process::Output) {
+    if !output.status.success() {
+        eprintln!("{}", format_output(step, output));
+        panic!();
+    }
+}
+
+pub(crate) fn format_output(
+    step: &str,
+    process::Output {
+        status,
+        stdout,
+        stderr,
+    }: &process::Output,
+) -> String {
+    let mut s = format!("\nFAILED[{}]: exit code {:?}\n", step, status.code());
+    s += &format!(
+        "FAILED[{}]: stdout:\n\n{}\n\n",
+        step,
+        String::from_utf8(stdout.to_vec()).unwrap()
+    );
+    s += &format!(
+        "FAILED[{}]: stderr:\n\n{}\n\n",
+        step,
+        String::from_utf8(stderr.to_vec()).unwrap()
+    );
+    s
+}
+
+pub(crate) fn ctype_and_cformat(x: &str) -> (&str, &str) {
+    match x {
+        "f32" => ("float", "%f"),
+        "f64" => ("double", "%f"),
+        "i32" => ("int32_t", "%d"),
+        _ => panic!("unknown type: {}", x),
+    }
+}

--- a/crates/libm-cdylib/src/test_utils.rs
+++ b/crates/libm-cdylib/src/test_utils.rs
@@ -122,6 +122,15 @@ pub(crate) fn format_output(
 /// as well as the printf format specifier used to print values of that type.
 pub(crate) fn ctype_and_printf_format_specifier(x: &str) -> (&str, &str) {
     match x {
+        // Note: fprintf has no format specifier for floats, `%f`, converts
+        // floats into a double, and prints that.
+        //
+        // For the linking tests, precision doesn't really matter. The only
+        // thing that's tested is whether our implementation was properly called
+        // or not. This is done by making our functions return an incorrect
+        // magic value, different from the correct result. So as long as this is
+        // precise enough for us to be able to parse `42.0` from stdout as
+        // 42_f32/f64, everything works.
         "f32" => ("float", "%f"),
         "f64" => ("double", "%f"),
         "i32" => ("int32_t", "%d"),

--- a/src/math/acos.rs
+++ b/src/math/acos.rs
@@ -62,7 +62,7 @@ fn r(z: f64) -> f64 {
 /// Returns values in radians, in the range of 0 to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-extern "C" pub fn acos(x: f64) -> f64 {
+pub fn acos(x: f64) -> f64 {
     let x1p_120f = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ -120
     let z: f64;
     let w: f64;

--- a/src/math/acos.rs
+++ b/src/math/acos.rs
@@ -62,7 +62,7 @@ fn r(z: f64) -> f64 {
 /// Returns values in radians, in the range of 0 to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn acos(x: f64) -> f64 {
+extern "C" pub fn acos(x: f64) -> f64 {
     let x1p_120f = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ -120
     let z: f64;
     let w: f64;


### PR DESCRIPTION
This PR adds a new crate `libm-cdylib` that implements the `<math.h>` API and that is ABI compatible with the platforms libm implementation. 

Since libm is usually dynamically linked, this allows replacing the libm implementation of any program in the platform with the Rust implementation, e.g., using `LD_PRELOAD` and similar APIs. 

The library is tested by just linking it to C programs that use `<cmath.h>` and checking that the library is called and produce expected "unique" results that differ from the system libraries. The C programs are linked to the system library, and then the math library is dynamically overriden.

Right now this works properly on macos, I'll iterate on the linux part of this on CI. 