### PR TITLE
Properly test wasm32-unknown-unknown on CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,12 @@ members = [
   "crates/libm-bench",
 ]
 
+[build-dependencies]
+rand = { version = "0.6.5", optional = true }
+
 [dev-dependencies]
 no-panic = "0.1.8"
 
-[build-dependencies]
-rand = { version = "0.6.5", optional = true }
+[target.wasm32-unknown-unknown.dev-dependencies]
+wasm-bindgen-test = "0.2.47"
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,17 +39,9 @@ jobs:
           TARGET: powerpc64le-unknown-linux-gnu
         x86_64:
           TARGET: x86_64-unknown-linux-gnu
-
-  - job: wasm
-    pool:
-      vmImage: ubuntu-16.04
-    steps:
-      - template: ci/azure-install-rust.yml
-      - script: rustup target add wasm32-unknown-unknown
-        displayName: "Install rust wasm target"
-      - script: sh ./ci/run.sh wasm32-unknown-unknown
-    variables:
-      TOOLCHAIN: nightly
+        wasm32:
+          TARGET: wasm32-unknown-unknown
+          TOOLCHAIN: nightly
 
   - job: rustfmt
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,10 +47,7 @@ jobs:
       - template: ci/azure-install-rust.yml
       - script: rustup target add wasm32-unknown-unknown
         displayName: "Install rust wasm target"
-      - script: cargo build --target wasm32-unknown-unknown
-        displayName: "Build for wasm"
-      - script: cargo build --target wasm32-unknown-unknown --no-default-features
-        displayName: "Build for wasm (no default features)"
+      - script: sh ./ci/run.sh wasm32-unknown-unknown
     variables:
       TOOLCHAIN: nightly
 

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,9 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    #[cfg(feature = "musl-reference-tests")]
-    musl_reference_tests::generate();
+    #[cfg(all(feature = "musl-reference-tests", target_os = "linux"))] {
+        musl_reference_tests::generate();
+    }
 
     if !cfg!(feature = "checked") {
         let lvl = env::var("OPT_LEVEL").unwrap();
@@ -14,7 +15,7 @@ fn main() {
     }
 }
 
-#[cfg(feature = "musl-reference-tests")]
+#[cfg(all(feature = "musl-reference-tests", target_os = "linux"))]
 mod musl_reference_tests {
     use rand::seq::SliceRandom;
     use rand::Rng;

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,8 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    #[cfg(all(feature = "musl-reference-tests", target_os = "linux"))] {
+    #[cfg(all(feature = "musl-reference-tests", target_os = "linux"))]
+    {
         musl_reference_tests::generate();
     }
 

--- a/ci/docker/wasm32-unknown-unknown/Dockerfile
+++ b/ci/docker/wasm32-unknown-unknown/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  clang \
+  cmake \
+  curl \
+  git \
+  libc6-dev \
+  make \
+  python \
+  xz-utils
+
+# Install `wasm2wat`
+RUN git clone --recursive https://github.com/WebAssembly/wabt
+RUN make -C wabt -j$(nproc)
+ENV PATH=$PATH:/wabt/bin
+
+# Install `node`
+RUN curl https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-x64.tar.xz | tar xJf -
+ENV PATH=$PATH:/node-v12.0.0-linux-x64/bin
+
+COPY docker/wasm32-unknown-unknown/wasm-entrypoint.sh /wasm-entrypoint.sh
+ENTRYPOINT ["/wasm-entrypoint.sh"]

--- a/ci/docker/wasm32-unknown-unknown/wasm-entrypoint.sh
+++ b/ci/docker/wasm32-unknown-unknown/wasm-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ex
+
+# Download an appropriate version of wasm-bindgen based off of what's being used
+# in the lock file. Ideally we'd use `wasm-pack` at some point for this!
+version=$(grep -A 1 'name = "wasm-bindgen"' Cargo.lock | grep version)
+version=$(echo $version | awk '{print $3}' | sed 's/"//g')
+curl -L https://github.com/rustwasm/wasm-bindgen/releases/download/$version/wasm-bindgen-$version-x86_64-unknown-linux-musl.tar.gz \
+   | tar xzf - -C target
+export PATH=$PATH:`pwd`/target/wasm-bindgen-$version-x86_64-unknown-linux-musl
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner
+export NODE_ARGS=--experimental-wasm-simd
+
+exec "$@"

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -12,7 +12,7 @@ run() {
     # will be owned by root
     mkdir -p target
 
-    docker build -t $target ci/docker/$target
+    docker build -t $target -f ci/docker/$target/Dockerfile ci/
     docker run \
            --rm \
            --user $(id -u):$(id -g) \
@@ -24,6 +24,7 @@ run() {
            -v `rustc --print sysroot`:/rust:ro \
            --init \
            -w /checkout \
+           --privileged \
            $target \
            sh -c "HOME=/tmp PATH=\$PATH:/rust/bin exec ci/run.sh $target"
 }

--- a/crates/compiler-builtins-smoke-test/Cargo.toml
+++ b/crates/compiler-builtins-smoke-test/Cargo.toml
@@ -3,4 +3,6 @@ name = "cb"
 version = "0.1.0"
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
 
-[dependencies]
+[features]
+default = []
+stable = []

--- a/crates/compiler-builtins-smoke-test/src/lib.rs
+++ b/crates/compiler-builtins-smoke-test/src/lib.rs
@@ -1,7 +1,7 @@
 //! Fake compiler-builtins crate
 //!
 //! This is used to test that we can source import `libm` into the compiler-builtins crate.
-
+#![cfg(not(test))]
 #![allow(dead_code)]
 #![no_std]
 #![cfg_attr(

--- a/crates/compiler-builtins-smoke-test/src/lib.rs
+++ b/crates/compiler-builtins-smoke-test/src/lib.rs
@@ -4,6 +4,10 @@
 
 #![allow(dead_code)]
 #![no_std]
+#![cfg_attr(
+    all(target_arch = "wasm32", not(feature = "stable")),
+    feature(core_intrinsics)
+)]
 
 #[path = "../../../src/math/mod.rs"]
 mod libm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
     feature(core_intrinsics)
 )]
 
+#[cfg(test)]
+use wasm_bindgen_test::wasm_bindgen_test;
+
 mod math;
 
 use core::{f32, f64};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
     feature(core_intrinsics)
 )]
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "wasm32"))]
+extern crate wasm_bindgen_test;
+#[cfg(all(test, target_arch = "wasm32"))]
 use wasm_bindgen_test::wasm_bindgen_test;
 
 mod math;

--- a/src/math/atan.rs
+++ b/src/math/atan.rs
@@ -141,7 +141,8 @@ mod tests {
     use super::atan;
     use core::f64;
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
         for (input, answer) in [
             (3.0_f64.sqrt() / 3.0, f64::consts::FRAC_PI_6),
@@ -163,22 +164,26 @@ mod tests {
         }
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn zero() {
         assert_eq!(atan(0.0), 0.0);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn infinity() {
         assert_eq!(atan(f64::INFINITY), f64::consts::FRAC_PI_2);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn minus_infinity() {
         assert_eq!(atan(f64::NEG_INFINITY), -f64::consts::FRAC_PI_2);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn nan() {
         assert!(atan(f64::NAN).is_nan());
     }

--- a/src/math/atan.rs
+++ b/src/math/atan.rs
@@ -138,7 +138,7 @@ pub fn atan(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::atan;
+    use crate::*;
     use core::f64;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/src/math/atan2.rs
+++ b/src/math/atan2.rs
@@ -116,7 +116,8 @@ pub fn atan2(y: f64, x: f64) -> f64 {
     }
 }
 
-#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
 fn sanity_check() {
     assert_eq!(atan2(0.0, 1.0), 0.0);
     assert_eq!(atan2(0.0, -1.0), PI);

--- a/src/math/atan2.rs
+++ b/src/math/atan2.rs
@@ -116,13 +116,19 @@ pub fn atan2(y: f64, x: f64) -> f64 {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-fn sanity_check() {
-    assert_eq!(atan2(0.0, 1.0), 0.0);
-    assert_eq!(atan2(0.0, -1.0), PI);
-    assert_eq!(atan2(-0.0, -1.0), -PI);
-    assert_eq!(atan2(3.0, 2.0), atan(3.0 / 2.0));
-    assert_eq!(atan2(2.0, -1.0), atan(2.0 / -1.0) + PI);
-    assert_eq!(atan2(-2.0, -1.0), atan(-2.0 / -1.0) - PI);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn sanity_check() {
+        assert_eq!(atan2(0.0, 1.0), 0.0);
+        assert_eq!(atan2(0.0, -1.0), PI);
+        assert_eq!(atan2(-0.0, -1.0), -PI);
+        assert_eq!(atan2(3.0, 2.0), atan(3.0 / 2.0));
+        assert_eq!(atan2(2.0, -1.0), atan(2.0 / -1.0) + PI);
+        assert_eq!(atan2(-2.0, -1.0), atan(-2.0 / -1.0) - PI);
+    }
 }

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -12,7 +12,7 @@ pub fn ceil(x: f64) -> f64 {
     // `f64.ceil` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::ceilf64(x) }
         }
     }

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -43,10 +43,11 @@ pub fn ceil(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
-        assert_eq!(super::ceil(1.1), 2.0);
-        assert_eq!(super::ceil(2.9), 3.0);
+        assert_eq!(ceil(1.1), 2.0);
+        assert_eq!(ceil(2.9), 3.0);
     }
 }

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -43,7 +43,8 @@ pub fn ceil(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
         assert_eq!(super::ceil(1.1), 2.0);
         assert_eq!(super::ceil(2.9), 3.0);

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -10,7 +10,7 @@ pub fn ceilf(x: f32) -> f32 {
     // `f32.ceil` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::ceilf32(x) }
         }
     }

--- a/src/math/exp2.rs
+++ b/src/math/exp2.rs
@@ -388,9 +388,13 @@ pub fn exp2(mut x: f64) -> f64 {
     scalbn(r, ki)
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-fn i0_wrap_test() {
-    let x = -3.0 / 256.0;
-    assert_eq!(exp2(x), f64::from_bits(0x3fefbdba3692d514));
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn i0_wrap_test() {
+        let x = -3.0 / 256.0;
+        assert_eq!(exp2(x), f64::from_bits(0x3fefbdba3692d514));
+    }
 }

--- a/src/math/exp2.rs
+++ b/src/math/exp2.rs
@@ -388,7 +388,8 @@ pub fn exp2(mut x: f64) -> f64 {
     scalbn(r, ki)
 }
 
-#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
 fn i0_wrap_test() {
     let x = -3.0 / 256.0;
     assert_eq!(exp2(x), f64::from_bits(0x3fefbdba3692d514));

--- a/src/math/expm1.rs
+++ b/src/math/expm1.rs
@@ -138,9 +138,10 @@ pub fn expm1(mut x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
-        assert_eq!(super::expm1(1.1), 2.0041660239464334);
+        assert_eq!(expm1(1.1), 2.0041660239464334);
     }
 }

--- a/src/math/expm1.rs
+++ b/src/math/expm1.rs
@@ -138,7 +138,8 @@ pub fn expm1(mut x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
         assert_eq!(super::expm1(1.1), 2.0041660239464334);
     }

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -10,7 +10,7 @@ pub fn fabs(x: f64) -> f64 {
     // `f64.abs` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::fabsf64(x) }
         }
     }

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -8,7 +8,7 @@ pub fn fabsf(x: f32) -> f32 {
     // `f32.abs` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::fabsf32(x) }
         }
     }

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -12,7 +12,7 @@ pub fn floor(x: f64) -> f64 {
     // `f64.floor` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::floorf64(x) }
         }
     }

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -10,7 +10,7 @@ pub fn floorf(x: f32) -> f32 {
     // `f32.floor` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::floorf32(x) }
         }
     }

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -43,7 +43,8 @@ pub fn floorf(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn no_overflow() {
         assert_eq!(super::floorf(0.5), 0.0);
     }

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -43,9 +43,10 @@ pub fn floorf(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn no_overflow() {
-        assert_eq!(super::floorf(0.5), 0.0);
+        assert_eq!(floorf(0.5), 0.0);
     }
 }

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -359,7 +359,7 @@ fn qonef(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{j1f, y1f};
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_j1f_2488() {

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -360,12 +360,14 @@ fn qonef(x: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{j1f, y1f};
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_j1f_2488() {
         // 0x401F3E49
         assert_eq!(j1f(2.4881766_f32), 0.49999475_f32);
     }
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_y1f_2002() {
         assert_eq!(y1f(2.0000002_f32), -0.10703229_f32);
     }

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -500,18 +500,21 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn zero_as_exponent() {
         test_sets_as_base(ALL, 0.0, 1.0);
         test_sets_as_base(ALL, -0.0, 1.0);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn one_as_base() {
         test_sets_as_exponent(1.0, ALL, 1.0);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn nan_inputs() {
         // NAN as the base:
         // (NAN ^ anything *but 0* should be NAN)
@@ -522,7 +525,8 @@ mod tests {
         test_sets_as_base(&ALL[..(ALL.len() - 2)], NAN, NAN);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn infinity_as_base() {
         // Positive Infinity as the base:
         // (+Infinity ^ positive anything but 0 and NAN should be +Infinity)
@@ -541,7 +545,8 @@ mod tests {
         test_sets(ALL, &|v: f64| pow(NEG_INFINITY, v), &|v: f64| pow(-0.0, -v));
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn infinity_as_exponent() {
         // Positive/Negative base greater than 1:
         // (pos/neg > 1 ^ Infinity should be Infinity - note this excludes NAN as the base)
@@ -567,7 +572,8 @@ mod tests {
         test_sets_as_base(&[NEG_ONE, POS_ONE], NEG_INFINITY, 1.0);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn zero_as_base() {
         // Positive Zero as the base:
         // (+0 ^ anything positive but 0 and NAN should be +0)
@@ -593,7 +599,8 @@ mod tests {
         test_sets_as_exponent(-0.0, &[NEG_ODDS], NEG_INFINITY);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn special_cases() {
         // One as the exponent:
         // (anything ^ 1 should be anything - i.e. the base)
@@ -624,7 +631,8 @@ mod tests {
         });
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn normal_cases() {
         assert_eq!(pow(2.0, 20.0), (1 << 20) as f64);
         assert_eq!(pow(-1.0, 9.0), -1.0);

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -415,7 +415,7 @@ mod tests {
 
     use self::core::f64::consts::{E, PI};
     use self::core::f64::{EPSILON, INFINITY, MAX, MIN, MIN_POSITIVE, NAN, NEG_INFINITY};
-    use super::pow;
+    use crate::*;
 
     const POS_ZERO: &[f64] = &[0.0];
     const NEG_ZERO: &[f64] = &[-0.0];

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -189,6 +189,8 @@ pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
 #[cfg(test)]
 mod tests {
     use super::rem_pio2;
+    #[cfg(target_arch = "wasm32")]
+    use crate::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -190,7 +190,8 @@ pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
 mod tests {
     use super::rem_pio2;
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_near_pi() {
         assert_eq!(
             rem_pio2(3.141592025756836),
@@ -210,12 +211,14 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_overflow_b9b847() {
         let _ = rem_pio2(-3054214.5490637687);
     }
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_overflow_4747b9() {
         let _ = rem_pio2(917340800458.2274);
     }

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -101,7 +101,8 @@ pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
 mod tests {
     use super::remquo;
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_q_overflow() {
         // 0xc000000000000001, 0x04c0000000000004
         let _ = remquo(-2.0000000000000004, 8.406091369059082e-286);

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -99,7 +99,7 @@ pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
 
 #[cfg(test)]
 mod tests {
-    use super::remquo;
+    use crate::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -38,7 +38,7 @@ pub fn round(mut x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::round;
+    use crate::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -40,7 +40,8 @@ pub fn round(mut x: f64) -> f64 {
 mod tests {
     use super::round;
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn negative_zero() {
         assert_eq!(round(-0.0_f64).to_bits(), (-0.0_f64).to_bits());
     }

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -36,7 +36,7 @@ pub fn roundf(mut x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::roundf;
+    use crate::*;
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -38,7 +38,8 @@ pub fn roundf(mut x: f32) -> f32 {
 mod tests {
     use super::roundf;
 
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn negative_zero() {
         assert_eq!(roundf(-0.0_f32).to_bits(), (-0.0_f32).to_bits());
     }

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -78,7 +78,8 @@ pub fn sin(x: f64) -> f64 {
     }
 }
 
-#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
 fn test_near_pi() {
     let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
     let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -78,10 +78,14 @@ pub fn sin(x: f64) -> f64 {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-fn test_near_pi() {
-    let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
-    let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7
-    assert_eq!(sin(x), sx);
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn test_near_pi() {
+        let x = f64::from_bits(0x400921fb000FD5DD); // 3.141592026217707
+        let sx = f64::from_bits(0x3ea50d15ced1a4a2); // 6.273720864039205e-7
+        assert_eq!(sin(x), sx);
+    }
 }

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -88,7 +88,7 @@ pub fn sqrt(x: f64) -> f64 {
     // `f64.sqrt` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return if x < 0.0 {
                 f64::NAN
             } else {

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -22,7 +22,7 @@ pub fn sqrtf(x: f32) -> f32 {
     // `f32.sqrt` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return if x < 0.0 {
                 ::core::f32::NAN
             } else {

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -34,7 +34,8 @@ pub fn trunc(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
         assert_eq!(super::trunc(1.1), 1.0);
     }

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -7,7 +7,7 @@ pub fn trunc(x: f64) -> f64 {
     // `f64.trunc` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::truncf64(x) }
         }
     }

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -34,9 +34,10 @@ pub fn trunc(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
-        assert_eq!(super::trunc(1.1), 1.0);
+        assert_eq!(trunc(1.1), 1.0);
     }
 }

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -34,7 +34,8 @@ pub fn truncf(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
         assert_eq!(super::truncf(1.1), 1.0);
     }

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -7,7 +7,7 @@ pub fn truncf(x: f32) -> f32 {
     // `f32.trunc` native instruction, so we can leverage this for both code size
     // and speed.
     llvm_intrinsically_optimized! {
-        #[cfg(target_arch = "wasm32")] {
+        #[cfg(all(target_arch = "wasm32", not(feature = "stable")))] {
             return unsafe { ::core::intrinsics::truncf32(x) }
         }
     }

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -34,9 +34,10 @@ pub fn truncf(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use crate::*;
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn sanity_check() {
-        assert_eq!(super::truncf(1.1), 1.0);
+        assert_eq!(truncf(1.1), 1.0);
     }
 }


### PR DESCRIPTION
Currently not all configurations are build for wasm32, and the llvm intrinsics are incorrectly feature gated.