### PR TITLE
Give the nounwind LLVM attribute to all public APIs

### DIFF
--- a/src/math/acos.rs
+++ b/src/math/acos.rs
@@ -62,7 +62,7 @@ fn r(z: f64) -> f64 {
 /// Returns values in radians, in the range of 0 to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn acos(x: f64) -> f64 {
+pub extern "C" fn acos(x: f64) -> f64 {
     let x1p_120f = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ -120
     let z: f64;
     let w: f64;

--- a/src/math/acosf.rs
+++ b/src/math/acosf.rs
@@ -36,7 +36,7 @@ fn r(z: f32) -> f32 {
 /// Returns values in radians, in the range of 0 to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn acosf(x: f32) -> f32 {
+pub extern "C" fn acosf(x: f32) -> f32 {
     let x1p_120 = f32::from_bits(0x03800000); // 0x1p-120 === 2 ^ (-120)
 
     let z: f32;

--- a/src/math/acosh.rs
+++ b/src/math/acosh.rs
@@ -7,7 +7,7 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 /// Calculates the inverse hyperbolic cosine of `x`.
 /// Is defined as `log(x + sqrt(x*x-1))`.
 /// `x` must be a number greater than or equal to 1.
-pub fn acosh(x: f64) -> f64 {
+pub extern "C" fn acosh(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
 

--- a/src/math/acoshf.rs
+++ b/src/math/acoshf.rs
@@ -7,7 +7,7 @@ const LN2: f32 = 0.693147180559945309417232121458176568;
 /// Calculates the inverse hyperbolic cosine of `x`.
 /// Is defined as `log(x + sqrt(x*x-1))`.
 /// `x` must be a number greater than or equal to 1.
-pub fn acoshf(x: f32) -> f32 {
+pub extern "C" fn acoshf(x: f32) -> f32 {
     let u = x.to_bits();
     let a = u & 0x7fffffff;
 

--- a/src/math/asin.rs
+++ b/src/math/asin.rs
@@ -69,7 +69,7 @@ fn comp_r(z: f64) -> f64 {
 /// Returns values in radians, in the range of -pi/2 to pi/2.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn asin(mut x: f64) -> f64 {
+pub extern "C" fn asin(mut x: f64) -> f64 {
     let z: f64;
     let r: f64;
     let s: f64;

--- a/src/math/asinf.rs
+++ b/src/math/asinf.rs
@@ -38,7 +38,7 @@ fn r(z: f32) -> f32 {
 /// Returns values in radians, in the range of -pi/2 to pi/2.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn asinf(mut x: f32) -> f32 {
+pub extern "C" fn asinf(mut x: f32) -> f32 {
     let x1p_120 = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ (-120)
 
     let hx = x.to_bits();

--- a/src/math/asinh.rs
+++ b/src/math/asinh.rs
@@ -7,7 +7,7 @@ const LN2: f64 = 0.693147180559945309417232121458176568; /* 0x3fe62e42,  0xfefa3
 ///
 /// Calculates the inverse hyperbolic sine of `x`.
 /// Is defined as `sgn(x)*log(|x|+sqrt(x*x+1))`.
-pub fn asinh(mut x: f64) -> f64 {
+pub extern "C" fn asinh(mut x: f64) -> f64 {
     let mut u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
     let sign = (u >> 63) != 0;

--- a/src/math/asinhf.rs
+++ b/src/math/asinhf.rs
@@ -7,7 +7,7 @@ const LN2: f32 = 0.693147180559945309417232121458176568;
 ///
 /// Calculates the inverse hyperbolic sine of `x`.
 /// Is defined as `sgn(x)*log(|x|+sqrt(x*x+1))`.
-pub fn asinhf(mut x: f32) -> f32 {
+pub extern "C" fn asinhf(mut x: f32) -> f32 {
     let u = x.to_bits();
     let i = u & 0x7fffffff;
     let sign = (u >> 31) != 0;

--- a/src/math/atan.rs
+++ b/src/math/atan.rs
@@ -66,7 +66,7 @@ const AT: [f64; 11] = [
 /// Returns a value in radians, in the range of -pi/2 to pi/2.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn atan(x: f64) -> f64 {
+pub extern "C" fn atan(x: f64) -> f64 {
     let mut x = x;
     let mut ix = (x.to_bits() >> 32) as u32;
     let sign = ix >> 31;

--- a/src/math/atan2.rs
+++ b/src/math/atan2.rs
@@ -50,7 +50,7 @@ const PI_LO: f64 = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
 /// Returns a value in radians, in the range of -pi to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn atan2(y: f64, x: f64) -> f64 {
+pub extern "C" fn atan2(y: f64, x: f64) -> f64 {
     if x.is_nan() || y.is_nan() {
         return x + y;
     }

--- a/src/math/atan2f.rs
+++ b/src/math/atan2f.rs
@@ -26,7 +26,7 @@ const PI_LO: f32 = -8.7422776573e-08; /* 0xb3bbbd2e */
 /// Returns a value in radians, in the range of -pi to pi.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn atan2f(y: f32, x: f32) -> f32 {
+pub extern "C" fn atan2f(y: f32, x: f32) -> f32 {
     if x.is_nan() || y.is_nan() {
         return x + y;
     }

--- a/src/math/atanf.rs
+++ b/src/math/atanf.rs
@@ -43,7 +43,7 @@ const A_T: [f32; 5] = [
 /// Returns a value in radians, in the range of -pi/2 to pi/2.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn atanf(mut x: f32) -> f32 {
+pub extern "C" fn atanf(mut x: f32) -> f32 {
     let x1p_120 = f32::from_bits(0x03800000); // 0x1p-120 === 2 ^ (-120)
 
     let z: f32;

--- a/src/math/atanh.rs
+++ b/src/math/atanh.rs
@@ -5,7 +5,7 @@ use super::log1p;
 ///
 /// Calculates the inverse hyperbolic tangent of `x`.
 /// Is defined as `log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2`.
-pub fn atanh(x: f64) -> f64 {
+pub extern "C" fn atanh(x: f64) -> f64 {
     let u = x.to_bits();
     let e = ((u >> 52) as usize) & 0x7ff;
     let sign = (u >> 63) != 0;

--- a/src/math/atanhf.rs
+++ b/src/math/atanhf.rs
@@ -5,7 +5,7 @@ use super::log1pf;
 ///
 /// Calculates the inverse hyperbolic tangent of `x`.
 /// Is defined as `log((1+x)/(1-x))/2 = log1p(2x/(1-x))/2`.
-pub fn atanhf(mut x: f32) -> f32 {
+pub extern "C" fn atanhf(mut x: f32) -> f32 {
     let mut u = x.to_bits();
     let sign = (u >> 31) != 0;
 

--- a/src/math/cbrt.rs
+++ b/src/math/cbrt.rs
@@ -32,7 +32,7 @@ const P4: f64 = 0.145996192886612446982; /* 0x3fc2b000, 0xd4e4edd7 */
 /// Computes the cube root of the argument.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn cbrt(x: f64) -> f64 {
+pub extern "C" fn cbrt(x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui: u64 = x.to_bits();

--- a/src/math/cbrtf.rs
+++ b/src/math/cbrtf.rs
@@ -27,7 +27,7 @@ const B2: u32 = 642849266; /* B2 = (127-127.0/3-24/3-0.03306235651)*2**23 */
 /// Computes the cube root of the argument.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn cbrtf(x: f32) -> f32 {
+pub extern "C" fn cbrtf(x: f32) -> f32 {
     let x1p24 = f32::from_bits(0x4b800000); // 0x1p24f === 2 ^ 24
 
     let mut r: f64;

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -7,7 +7,7 @@ const TOINT: f64 = 1. / f64::EPSILON;
 /// Finds the nearest integer greater than or equal to `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ceil(x: f64) -> f64 {
+pub extern "C" fn ceil(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.ceil` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -5,7 +5,7 @@ use core::f32;
 /// Finds the nearest integer greater than or equal to `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ceilf(x: f32) -> f32 {
+pub extern "C" fn ceilf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.ceil` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/copysign.rs
+++ b/src/math/copysign.rs
@@ -2,7 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
-pub fn copysign(x: f64, y: f64) -> f64 {
+pub extern "C" fn copysign(x: f64, y: f64) -> f64 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= (!0) >> 1;

--- a/src/math/copysignf.rs
+++ b/src/math/copysignf.rs
@@ -2,7 +2,7 @@
 ///
 /// Constructs a number with the magnitude (absolute value) of its
 /// first argument, `x`, and the sign of its second argument, `y`.
-pub fn copysignf(x: f32, y: f32) -> f32 {
+pub extern "C" fn copysignf(x: f32, y: f32) -> f32 {
     let mut ux = x.to_bits();
     let uy = y.to_bits();
     ux &= 0x7fffffff;

--- a/src/math/cos.rs
+++ b/src/math/cos.rs
@@ -43,7 +43,7 @@ use super::{k_cos, k_sin, rem_pio2};
 //
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn cos(x: f64) -> f64 {
+pub extern "C" fn cos(x: f64) -> f64 {
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;
 
     /* |x| ~< pi/4 */

--- a/src/math/cosf.rs
+++ b/src/math/cosf.rs
@@ -26,7 +26,7 @@ const C4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn cosf(x: f32) -> f32 {
+pub extern "C" fn cosf(x: f32) -> f32 {
     let x64 = x as f64;
 
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120

--- a/src/math/cosh.rs
+++ b/src/math/cosh.rs
@@ -9,7 +9,7 @@ use super::k_expo2;
 /// Angles are specified in radians.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn cosh(mut x: f64) -> f64 {
+pub extern "C" fn cosh(mut x: f64) -> f64 {
     /* |x| */
     let mut ix = x.to_bits();
     ix &= 0x7fffffffffffffff;

--- a/src/math/coshf.rs
+++ b/src/math/coshf.rs
@@ -9,7 +9,7 @@ use super::k_expo2f;
 /// Angles are specified in radians.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn coshf(mut x: f32) -> f32 {
+pub extern "C" fn coshf(mut x: f32) -> f32 {
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120
 
     /* |x| */

--- a/src/math/erf.rs
+++ b/src/math/erf.rs
@@ -219,7 +219,7 @@ fn erfc2(ix: u32, mut x: f64) -> f64 {
 /// Calculates an approximation to the “error function”, which estimates
 /// the probability that an observation will fall within x standard
 /// deviations of the mean (assuming a normal distribution).
-pub fn erf(x: f64) -> f64 {
+pub extern "C" fn erf(x: f64) -> f64 {
     let r: f64;
     let s: f64;
     let z: f64;
@@ -268,7 +268,7 @@ pub fn erf(x: f64) -> f64 {
 /// Is `1 - erf(x)`. Is computed directly, so that you can use it to avoid
 /// the loss of precision that would result from subtracting
 /// large probabilities (on large `x`) from 1.
-pub fn erfc(x: f64) -> f64 {
+pub extern "C" fn erfc(x: f64) -> f64 {
     let r: f64;
     let s: f64;
     let z: f64;

--- a/src/math/erff.rs
+++ b/src/math/erff.rs
@@ -130,7 +130,7 @@ fn erfc2(mut ix: u32, mut x: f32) -> f32 {
 /// Calculates an approximation to the “error function”, which estimates
 /// the probability that an observation will fall within x standard
 /// deviations of the mean (assuming a normal distribution).
-pub fn erff(x: f32) -> f32 {
+pub extern "C" fn erff(x: f32) -> f32 {
     let r: f32;
     let s: f32;
     let z: f32;
@@ -179,7 +179,7 @@ pub fn erff(x: f32) -> f32 {
 /// Is `1 - erf(x)`. Is computed directly, so that you can use it to avoid
 /// the loss of precision that would result from subtracting
 /// large probabilities (on large `x`) from 1.
-pub fn erfcf(x: f32) -> f32 {
+pub extern "C" fn erfcf(x: f32) -> f32 {
     let r: f32;
     let s: f32;
     let z: f32;

--- a/src/math/exp.rs
+++ b/src/math/exp.rs
@@ -83,7 +83,7 @@ const P5: f64 = 4.13813679705723846039e-08; /* 0x3E663769, 0x72BEA4D0 */
 /// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn exp(mut x: f64) -> f64 {
+pub extern "C" fn exp(mut x: f64) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023
     let x1p_149 = f64::from_bits(0x36a0000000000000); // 0x1p-149 === 2 ^ -149
 

--- a/src/math/exp10.rs
+++ b/src/math/exp10.rs
@@ -6,7 +6,7 @@ const P10: &[f64] = &[
     1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
 ];
 
-pub fn exp10(x: f64) -> f64 {
+pub extern "C" fn exp10(x: f64) -> f64 {
     let (mut y, n) = modf(x);
     let u: u64 = n.to_bits();
     /* fabs(n) < 16 without raising invalid on nan */

--- a/src/math/exp10f.rs
+++ b/src/math/exp10f.rs
@@ -6,7 +6,7 @@ const P10: &[f32] = &[
     1e-7, 1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7,
 ];
 
-pub fn exp10f(x: f32) -> f32 {
+pub extern "C" fn exp10f(x: f32) -> f32 {
     let (mut y, n) = modff(x);
     let u = n.to_bits();
     /* fabsf(n) < 8 without raising invalid on nan */

--- a/src/math/exp2.rs
+++ b/src/math/exp2.rs
@@ -324,7 +324,7 @@ static TBL: [u64; TBLSIZE * 2] = [
 /// Calculate `2^x`, that is, 2 raised to the power `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn exp2(mut x: f64) -> f64 {
+pub extern "C" fn exp2(mut x: f64) -> f64 {
     let redux = f64::from_bits(0x4338000000000000) / TBLSIZE as f64;
     let p1 = f64::from_bits(0x3fe62e42fefa39ef);
     let p2 = f64::from_bits(0x3fcebfbdff82c575);

--- a/src/math/exp2f.rs
+++ b/src/math/exp2f.rs
@@ -75,7 +75,7 @@ static EXP2FT: [u64; TBLSIZE] = [
 /// Calculate `2^x`, that is, 2 raised to the power `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn exp2f(mut x: f32) -> f32 {
+pub extern "C" fn exp2f(mut x: f32) -> f32 {
     let redux = f32::from_bits(0x4b400000) / TBLSIZE as f32;
     let p1 = f32::from_bits(0x3f317218);
     let p2 = f32::from_bits(0x3e75fdf0);

--- a/src/math/expf.rs
+++ b/src/math/expf.rs
@@ -32,7 +32,7 @@ const P2: f32 = -2.7667332906e-3; /* -0xb55215.0p-32 */
 /// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn expf(mut x: f32) -> f32 {
+pub extern "C" fn expf(mut x: f32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127
     let x1p_126 = f32::from_bits(0x800000); // 0x1p-126f === 2 ^ -126  /*original 0x1p-149f    ??????????? */
     let mut hx = x.to_bits();

--- a/src/math/expm1.rs
+++ b/src/math/expm1.rs
@@ -32,7 +32,7 @@ const Q5: f64 = -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
 /// where using `exp(x)-1` would lose many significant digits.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn expm1(mut x: f64) -> f64 {
+pub extern "C" fn expm1(mut x: f64) -> f64 {
     let hi: f64;
     let lo: f64;
     let k: i32;

--- a/src/math/expm1f.rs
+++ b/src/math/expm1f.rs
@@ -34,7 +34,7 @@ const Q2: f32 = 1.5807170421e-3; /*  0xcf3010.0p-33 */
 /// where using `exp(x)-1` would lose many significant digits.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn expm1f(mut x: f32) -> f32 {
+pub extern "C" fn expm1f(mut x: f32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127
 
     let mut hx = x.to_bits();

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -5,7 +5,7 @@ use core::u64;
 /// by direct manipulation of the bit representation of `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabs(x: f64) -> f64 {
+pub extern "C" fn fabs(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.abs` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -3,7 +3,7 @@
 /// by direct manipulation of the bit representation of `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fabsf(x: f32) -> f32 {
+pub extern "C" fn fabsf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.abs` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/fdim.rs
+++ b/src/math/fdim.rs
@@ -10,7 +10,7 @@ use core::f64;
 /// A range error may occur.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fdim(x: f64, y: f64) -> f64 {
+pub extern "C" fn fdim(x: f64, y: f64) -> f64 {
     if x.is_nan() {
         x
     } else if y.is_nan() {

--- a/src/math/fdimf.rs
+++ b/src/math/fdimf.rs
@@ -10,7 +10,7 @@ use core::f32;
 /// A range error may occur.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fdimf(x: f32, y: f32) -> f32 {
+pub extern "C" fn fdimf(x: f32, y: f32) -> f32 {
     if x.is_nan() {
         x
     } else if y.is_nan() {

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -7,7 +7,7 @@ const TOINT: f64 = 1. / f64::EPSILON;
 /// Finds the nearest integer less than or equal to `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn floor(x: f64) -> f64 {
+pub extern "C" fn floor(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.floor` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -5,7 +5,7 @@ use core::f32;
 /// Finds the nearest integer less than or equal to `x`.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn floorf(x: f32) -> f32 {
+pub extern "C" fn floorf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.floor` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -55,7 +55,7 @@ fn mul(x: u64, y: u64) -> (u64, u64) {
 /// according to the rounding mode characterized by the value of FLT_ROUNDS.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fma(x: f64, y: f64, z: f64) -> f64 {
+pub extern "C" fn fma(x: f64, y: f64, z: f64) -> f64 {
     let x1p63: f64 = f64::from_bits(0x43e0000000000000); // 0x1p63 === 2 ^ 63
     let x0_ffffff8p_63 = f64::from_bits(0x3bfffffff0000000); // 0x0.ffffff8p-63
 

--- a/src/math/fmaf.rs
+++ b/src/math/fmaf.rs
@@ -48,7 +48,7 @@ use super::fenv::{
 /// according to the rounding mode characterized by the value of FLT_ROUNDS.
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmaf(x: f32, y: f32, mut z: f32) -> f32 {
+pub extern "C" fn fmaf(x: f32, y: f32, mut z: f32) -> f32 {
     let xy: f64;
     let mut result: f64;
     let mut ui: u64;

--- a/src/math/fmax.rs
+++ b/src/math/fmax.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmax(x: f64, y: f64) -> f64 {
+pub extern "C" fn fmax(x: f64, y: f64) -> f64 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmaxf.rs
+++ b/src/math/fmaxf.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmaxf(x: f32, y: f32) -> f32 {
+pub extern "C" fn fmaxf(x: f32, y: f32) -> f32 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmin.rs
+++ b/src/math/fmin.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmin(x: f64, y: f64) -> f64 {
+pub extern "C" fn fmin(x: f64, y: f64) -> f64 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fminf.rs
+++ b/src/math/fminf.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fminf(x: f32, y: f32) -> f32 {
+pub extern "C" fn fminf(x: f32, y: f32) -> f32 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the
     // canonicalized number if one operand is a number and the other a quiet NaN. Otherwise it
     // is either x or y, canonicalized (this means results might differ among implementations).

--- a/src/math/fmod.rs
+++ b/src/math/fmod.rs
@@ -2,7 +2,7 @@ use core::u64;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmod(x: f64, y: f64) -> f64 {
+pub extern "C" fn fmod(x: f64, y: f64) -> f64 {
     let mut uxi = x.to_bits();
     let mut uyi = y.to_bits();
     let mut ex = (uxi >> 52 & 0x7ff) as i64;

--- a/src/math/fmodf.rs
+++ b/src/math/fmodf.rs
@@ -3,7 +3,7 @@ use core::u32;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn fmodf(x: f32, y: f32) -> f32 {
+pub extern "C" fn fmodf(x: f32, y: f32) -> f32 {
     let mut uxi = x.to_bits();
     let mut uyi = y.to_bits();
     let mut ex = (uxi >> 23 & 0xff) as i32;

--- a/src/math/frexp.rs
+++ b/src/math/frexp.rs
@@ -1,4 +1,4 @@
-pub fn frexp(x: f64) -> (f64, i32) {
+pub extern "C" fn frexp(x: f64) -> (f64, i32) {
     let mut y = x.to_bits();
     let ee = ((y >> 52) & 0x7ff) as i32;
 

--- a/src/math/frexpf.rs
+++ b/src/math/frexpf.rs
@@ -1,4 +1,4 @@
-pub fn frexpf(x: f32) -> (f32, i32) {
+pub extern "C" fn frexpf(x: f32) -> (f32, i32) {
     let mut y = x.to_bits();
     let ee: i32 = ((y >> 23) & 0xff) as i32;
 

--- a/src/math/hypot.rs
+++ b/src/math/hypot.rs
@@ -20,7 +20,7 @@ fn sq(x: f64) -> (f64, f64) {
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn hypot(mut x: f64, mut y: f64) -> f64 {
+pub extern "C" fn hypot(mut x: f64, mut y: f64) -> f64 {
     let x1p700 = f64::from_bits(0x6bb0000000000000); // 0x1p700 === 2 ^ 700
     let x1p_700 = f64::from_bits(0x1430000000000000); // 0x1p-700 === 2 ^ -700
 

--- a/src/math/hypotf.rs
+++ b/src/math/hypotf.rs
@@ -4,7 +4,7 @@ use super::sqrtf;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn hypotf(mut x: f32, mut y: f32) -> f32 {
+pub extern "C" fn hypotf(mut x: f32, mut y: f32) -> f32 {
     let x1p90 = f32::from_bits(0x6c800000); // 0x1p90f === 2 ^ 90
     let x1p_90 = f32::from_bits(0x12800000); // 0x1p-90f === 2 ^ -90
 

--- a/src/math/ilogb.rs
+++ b/src/math/ilogb.rs
@@ -1,7 +1,7 @@
 const FP_ILOGBNAN: i32 = -1 - 0x7fffffff;
 const FP_ILOGB0: i32 = FP_ILOGBNAN;
 
-pub fn ilogb(x: f64) -> i32 {
+pub extern "C" fn ilogb(x: f64) -> i32 {
     let mut i: u64 = x.to_bits();
     let e = ((i >> 52) & 0x7ff) as i32;
 

--- a/src/math/ilogbf.rs
+++ b/src/math/ilogbf.rs
@@ -1,7 +1,7 @@
 const FP_ILOGBNAN: i32 = -1 - 0x7fffffff;
 const FP_ILOGB0: i32 = FP_ILOGBNAN;
 
-pub fn ilogbf(x: f32) -> i32 {
+pub extern "C" fn ilogbf(x: f32) -> i32 {
     let mut i = x.to_bits();
     let e = ((i >> 23) & 0xff) as i32;
 

--- a/src/math/j0.rs
+++ b/src/math/j0.rs
@@ -109,7 +109,7 @@ const S02: f64 = 1.16926784663337450260e-04; /* 0x3F1EA6D2, 0xDD57DBF4 */
 const S03: f64 = 5.13546550207318111446e-07; /* 0x3EA13B54, 0xCE84D5A9 */
 const S04: f64 = 1.16614003333790000205e-09; /* 0x3E1408BC, 0xF4745D8F */
 
-pub fn j0(mut x: f64) -> f64 {
+pub extern "C" fn j0(mut x: f64) -> f64 {
     let z: f64;
     let r: f64;
     let s: f64;
@@ -162,7 +162,7 @@ const V02: f64 = 7.60068627350353253702e-05; /* 0x3F13ECBB, 0xF578C6C1 */
 const V03: f64 = 2.59150851840457805467e-07; /* 0x3E91642D, 0x7FF202FD */
 const V04: f64 = 4.41110311332675467403e-10; /* 0x3DFE5018, 0x3BD6D9EF */
 
-pub fn y0(x: f64) -> f64 {
+pub extern "C" fn y0(x: f64) -> f64 {
     let z: f64;
     let u: f64;
     let v: f64;

--- a/src/math/j0f.rs
+++ b/src/math/j0f.rs
@@ -62,7 +62,7 @@ const S02: f32 = 1.1692678527e-04; /* 0x38f53697 */
 const S03: f32 = 5.1354652442e-07; /* 0x3509daa6 */
 const S04: f32 = 1.1661400734e-09; /* 0x30a045e8 */
 
-pub fn j0f(mut x: f32) -> f32 {
+pub extern "C" fn j0f(mut x: f32) -> f32 {
     let z: f32;
     let r: f32;
     let s: f32;
@@ -107,7 +107,7 @@ const V02: f32 = 7.6006865129e-05; /* 0x389f65e0 */
 const V03: f32 = 2.5915085189e-07; /* 0x348b216c */
 const V04: f32 = 4.4111031494e-10; /* 0x2ff280c2 */
 
-pub fn y0f(x: f32) -> f32 {
+pub extern "C" fn y0f(x: f32) -> f32 {
     let z: f32;
     let u: f32;
     let v: f32;

--- a/src/math/j1.rs
+++ b/src/math/j1.rs
@@ -113,7 +113,7 @@ const S03: f64 = 1.17718464042623683263e-06; /* 0x3EB3BFF8, 0x333F8498 */
 const S04: f64 = 5.04636257076217042715e-09; /* 0x3E35AC88, 0xC97DFF2C */
 const S05: f64 = 1.23542274426137913908e-11; /* 0x3DAB2ACF, 0xCFB97ED8 */
 
-pub fn j1(x: f64) -> f64 {
+pub extern "C" fn j1(x: f64) -> f64 {
     let mut z: f64;
     let r: f64;
     let s: f64;
@@ -158,7 +158,7 @@ const V0: [f64; 5] = [
     1.66559246207992079114e-11, /* 0x3DB25039, 0xDACA772A */
 ];
 
-pub fn y1(x: f64) -> f64 {
+pub extern "C" fn y1(x: f64) -> f64 {
     let z: f64;
     let u: f64;
     let v: f64;

--- a/src/math/j1f.rs
+++ b/src/math/j1f.rs
@@ -63,7 +63,7 @@ const S03: f32 = 1.1771846857e-06; /* 0x359dffc2 */
 const S04: f32 = 5.0463624390e-09; /* 0x31ad6446 */
 const S05: f32 = 1.2354227016e-11; /* 0x2d59567e */
 
-pub fn j1f(x: f32) -> f32 {
+pub extern "C" fn j1f(x: f32) -> f32 {
     let mut z: f32;
     let r: f32;
     let s: f32;
@@ -107,7 +107,7 @@ const V0: [f32; 5] = [
     1.6655924903e-11, /* 0x2d9281cf */
 ];
 
-pub fn y1f(x: f32) -> f32 {
+pub extern "C" fn y1f(x: f32) -> f32 {
     let z: f32;
     let u: f32;
     let v: f32;

--- a/src/math/jn.rs
+++ b/src/math/jn.rs
@@ -38,7 +38,7 @@ use super::{cos, fabs, get_high_word, get_low_word, j0, j1, log, sin, sqrt, y0, 
 
 const INVSQRTPI: f64 = 5.64189583547756279280e-01; /* 0x3FE20DD7, 0x50429B6D */
 
-pub fn jn(n: i32, mut x: f64) -> f64 {
+pub extern "C" fn jn(n: i32, mut x: f64) -> f64 {
     let mut ix: u32;
     let lx: u32;
     let nm1: i32;
@@ -251,7 +251,7 @@ pub fn jn(n: i32, mut x: f64) -> f64 {
     }
 }
 
-pub fn yn(n: i32, x: f64) -> f64 {
+pub extern "C" fn yn(n: i32, x: f64) -> f64 {
     let mut ix: u32;
     let lx: u32;
     let mut ib: u32;

--- a/src/math/jnf.rs
+++ b/src/math/jnf.rs
@@ -15,7 +15,7 @@
 
 use super::{fabsf, j0f, j1f, logf, y0f, y1f};
 
-pub fn jnf(n: i32, mut x: f32) -> f32 {
+pub extern "C" fn jnf(n: i32, mut x: f32) -> f32 {
     let mut ix: u32;
     let mut nm1: i32;
     let mut sign: bool;
@@ -195,7 +195,7 @@ pub fn jnf(n: i32, mut x: f32) -> f32 {
     }
 }
 
-pub fn ynf(n: i32, x: f32) -> f32 {
+pub extern "C" fn ynf(n: i32, x: f32) -> f32 {
     let mut ix: u32;
     let mut ib: u32;
     let nm1: i32;

--- a/src/math/ldexp.rs
+++ b/src/math/ldexp.rs
@@ -1,5 +1,5 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ldexp(x: f64, n: i32) -> f64 {
+pub extern "C" fn ldexp(x: f64, n: i32) -> f64 {
     super::scalbn(x, n)
 }

--- a/src/math/ldexpf.rs
+++ b/src/math/ldexpf.rs
@@ -1,5 +1,5 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn ldexpf(x: f32, n: i32) -> f32 {
+pub extern "C" fn ldexpf(x: f32, n: i32) -> f32 {
     super::scalbnf(x, n)
 }

--- a/src/math/lgamma.rs
+++ b/src/math/lgamma.rs
@@ -1,5 +1,5 @@
 use super::lgamma_r;
 
-pub fn lgamma(x: f64) -> f64 {
+pub extern "C" fn lgamma(x: f64) -> f64 {
     lgamma_r(x).0
 }

--- a/src/math/lgamma_r.rs
+++ b/src/math/lgamma_r.rs
@@ -164,7 +164,7 @@ fn sin_pi(mut x: f64) -> f64 {
     }
 }
 
-pub fn lgamma_r(mut x: f64) -> (f64, i32) {
+pub extern "C" fn lgamma_r(mut x: f64) -> (f64, i32) {
     let u: u64 = x.to_bits();
     let mut t: f64;
     let y: f64;

--- a/src/math/lgammaf.rs
+++ b/src/math/lgammaf.rs
@@ -1,5 +1,5 @@
 use super::lgammaf_r;
 
-pub fn lgammaf(x: f32) -> f32 {
+pub extern "C" fn lgammaf(x: f32) -> f32 {
     lgammaf_r(x).0
 }

--- a/src/math/lgammaf_r.rs
+++ b/src/math/lgammaf_r.rs
@@ -99,7 +99,7 @@ fn sin_pi(mut x: f32) -> f32 {
     }
 }
 
-pub fn lgammaf_r(mut x: f32) -> (f32, i32) {
+pub extern "C" fn lgammaf_r(mut x: f32) -> (f32, i32) {
     let u = x.to_bits();
     let mut t: f32;
     let y: f32;

--- a/src/math/log.rs
+++ b/src/math/log.rs
@@ -72,7 +72,7 @@ const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log(mut x: f64) -> f64 {
+pub extern "C" fn log(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui = x.to_bits();

--- a/src/math/log10.rs
+++ b/src/math/log10.rs
@@ -33,7 +33,7 @@ const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log10(mut x: f64) -> f64 {
+pub extern "C" fn log10(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui: u64 = x.to_bits();

--- a/src/math/log10f.rs
+++ b/src/math/log10f.rs
@@ -27,7 +27,7 @@ const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log10f(mut x: f32) -> f32 {
+pub extern "C" fn log10f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25
 
     let mut ui: u32 = x.to_bits();

--- a/src/math/log1p.rs
+++ b/src/math/log1p.rs
@@ -67,7 +67,7 @@ const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log1p(x: f64) -> f64 {
+pub extern "C" fn log1p(x: f64) -> f64 {
     let mut ui: u64 = x.to_bits();
     let hfsq: f64;
     let mut f: f64 = 0.;

--- a/src/math/log1pf.rs
+++ b/src/math/log1pf.rs
@@ -22,7 +22,7 @@ const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log1pf(x: f32) -> f32 {
+pub extern "C" fn log1pf(x: f32) -> f32 {
     let mut ui: u32 = x.to_bits();
     let hfsq: f32;
     let mut f: f32 = 0.;

--- a/src/math/log2.rs
+++ b/src/math/log2.rs
@@ -31,7 +31,7 @@ const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log2(mut x: f64) -> f64 {
+pub extern "C" fn log2(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
 
     let mut ui: u64 = x.to_bits();

--- a/src/math/log2f.rs
+++ b/src/math/log2f.rs
@@ -25,7 +25,7 @@ const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn log2f(mut x: f32) -> f32 {
+pub extern "C" fn log2f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25
 
     let mut ui: u32 = x.to_bits();

--- a/src/math/logf.rs
+++ b/src/math/logf.rs
@@ -23,7 +23,7 @@ const LG4: f32 = 0.24279078841; /*  0xf89e26.0p-26 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn logf(mut x: f32) -> f32 {
+pub extern "C" fn logf(mut x: f32) -> f32 {
     let x1p25 = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25
 
     let mut ix = x.to_bits();

--- a/src/math/modf.rs
+++ b/src/math/modf.rs
@@ -1,4 +1,4 @@
-pub fn modf(x: f64) -> (f64, f64) {
+pub extern "C" fn modf(x: f64) -> (f64, f64) {
     let rv2: f64;
     let mut u = x.to_bits();
     let mask: u64;

--- a/src/math/modff.rs
+++ b/src/math/modff.rs
@@ -1,4 +1,4 @@
-pub fn modff(x: f32) -> (f32, f32) {
+pub extern "C" fn modff(x: f32) -> (f32, f32) {
     let rv2: f32;
     let mut u: u32 = x.to_bits();
     let mask: u32;

--- a/src/math/nextafter.rs
+++ b/src/math/nextafter.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn nextafter(x: f64, y: f64) -> f64 {
+pub extern "C" fn nextafter(x: f64, y: f64) -> f64 {
     if x.is_nan() || y.is_nan() {
         return x + y;
     }

--- a/src/math/nextafterf.rs
+++ b/src/math/nextafterf.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn nextafterf(x: f32, y: f32) -> f32 {
+pub extern "C" fn nextafterf(x: f32, y: f32) -> f32 {
     if x.is_nan() || y.is_nan() {
         return x + y;
     }

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -91,7 +91,7 @@ const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 t
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn pow(x: f64, y: f64) -> f64 {
+pub extern "C" fn pow(x: f64, y: f64) -> f64 {
     let t1: f64;
     let t2: f64;
 

--- a/src/math/powf.rs
+++ b/src/math/powf.rs
@@ -45,7 +45,7 @@ const IVLN2_L: f32 = 7.0526075433e-06;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn powf(x: f32, y: f32) -> f32 {
+pub extern "C" fn powf(x: f32, y: f32) -> f32 {
     let mut z: f32;
     let mut ax: f32;
     let z_h: f32;

--- a/src/math/remainder.rs
+++ b/src/math/remainder.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remainder(x: f64, y: f64) -> f64 {
+pub extern "C" fn remainder(x: f64, y: f64) -> f64 {
     let (result, _) = super::remquo(x, y);
     result
 }

--- a/src/math/remainderf.rs
+++ b/src/math/remainderf.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn remainderf(x: f32, y: f32) -> f32 {
+pub extern "C" fn remainderf(x: f32, y: f32) -> f32 {
     let (result, _) = super::remquof(x, y);
     result
 }

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -1,4 +1,4 @@
-pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
+pub extern "C" fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
     let ux: u64 = x.to_bits();
     let mut uy: u64 = y.to_bits();
     let mut ex = ((ux >> 52) & 0x7ff) as i32;

--- a/src/math/remquof.rs
+++ b/src/math/remquof.rs
@@ -1,4 +1,4 @@
-pub fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
+pub extern "C" fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
     let ux: u32 = x.to_bits();
     let mut uy: u32 = y.to_bits();
     let mut ex = ((ux >> 23) & 0xff) as i32;

--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -4,7 +4,7 @@ const TOINT: f64 = 1.0 / f64::EPSILON;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn round(mut x: f64) -> f64 {
+pub extern "C" fn round(mut x: f64) -> f64 {
     let i = x.to_bits();
     let e: u64 = i >> 52 & 0x7ff;
     let mut y: f64;

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -4,7 +4,7 @@ const TOINT: f32 = 1.0 / f32::EPSILON;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn roundf(mut x: f32) -> f32 {
+pub extern "C" fn roundf(mut x: f32) -> f32 {
     let i = x.to_bits();
     let e: u32 = i >> 23 & 0xff;
     let mut y: f32;

--- a/src/math/scalbn.rs
+++ b/src/math/scalbn.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn scalbn(x: f64, mut n: i32) -> f64 {
+pub extern "C" fn scalbn(x: f64, mut n: i32) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023
     let x1p53 = f64::from_bits(0x4340000000000000); // 0x1p53 === 2 ^ 53
     let x1p_1022 = f64::from_bits(0x0010000000000000); // 0x1p-1022 === 2 ^ (-1022)

--- a/src/math/scalbnf.rs
+++ b/src/math/scalbnf.rs
@@ -1,6 +1,6 @@
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn scalbnf(mut x: f32, mut n: i32) -> f32 {
+pub extern "C" fn scalbnf(mut x: f32, mut n: i32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127
     let x1p_126 = f32::from_bits(0x800000); // 0x1p-126f === 2 ^ -126
     let x1p24 = f32::from_bits(0x4b800000); // 0x1p24f === 2 ^ 24

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -42,7 +42,7 @@ use super::{k_cos, k_sin, rem_pio2};
 //      TRIG(x) returns trig(x) nearly rounded
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sin(x: f64) -> f64 {
+pub extern "C" fn sin(x: f64) -> f64 {
     let x1p120 = f64::from_bits(0x4770000000000000); // 0x1p120f === 2 ^ 120
 
     /* High word of x. */

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -12,7 +12,7 @@
 
 use super::{get_high_word, k_cos, k_sin, rem_pio2};
 
-pub fn sincos(x: f64) -> (f64, f64) {
+pub extern "C" fn sincos(x: f64) -> (f64, f64) {
     let s: f64;
     let c: f64;
     let mut ix: u32;

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -23,7 +23,7 @@ const S2PIO2: f32 = 2.0 * PI_2; /* 0x400921FB, 0x54442D18 */
 const S3PIO2: f32 = 3.0 * PI_2; /* 0x4012D97C, 0x7F3321D2 */
 const S4PIO2: f32 = 4.0 * PI_2; /* 0x401921FB, 0x54442D18 */
 
-pub fn sincosf(x: f32) -> (f32, f32) {
+pub extern "C" fn sincosf(x: f32) -> (f32, f32) {
     let s: f32;
     let c: f32;
     let mut ix: u32;

--- a/src/math/sinf.rs
+++ b/src/math/sinf.rs
@@ -26,7 +26,7 @@ const S4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sinf(x: f32) -> f32 {
+pub extern "C" fn sinf(x: f32) -> f32 {
     let x64 = x as f64;
 
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120

--- a/src/math/sinh.rs
+++ b/src/math/sinh.rs
@@ -6,7 +6,7 @@ use super::{expm1, expo2};
 //
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sinh(x: f64) -> f64 {
+pub extern "C" fn sinh(x: f64) -> f64 {
     // union {double f; uint64_t i;} u = {.f = x};
     // uint32_t w;
     // double t, h, absx;

--- a/src/math/sinhf.rs
+++ b/src/math/sinhf.rs
@@ -3,7 +3,7 @@ use super::k_expo2f;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sinhf(x: f32) -> f32 {
+pub extern "C" fn sinhf(x: f32) -> f32 {
     let mut h = 0.5f32;
     let mut ix = x.to_bits();
     if (ix >> 31) != 0 {

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -83,7 +83,7 @@ const TINY: f64 = 1.0e-300;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sqrt(x: f64) -> f64 {
+pub extern "C" fn sqrt(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.sqrt` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -17,7 +17,7 @@ const TINY: f32 = 1.0e-30;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn sqrtf(x: f32) -> f32 {
+pub extern "C" fn sqrtf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.sqrt` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/tan.rs
+++ b/src/math/tan.rs
@@ -41,7 +41,7 @@ use super::{k_tan, rem_pio2};
 //      TRIG(x) returns trig(x) nearly rounded
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn tan(x: f64) -> f64 {
+pub extern "C" fn tan(x: f64) -> f64 {
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120
 
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;

--- a/src/math/tanf.rs
+++ b/src/math/tanf.rs
@@ -26,7 +26,7 @@ const T4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn tanf(x: f32) -> f32 {
+pub extern "C" fn tanf(x: f32) -> f32 {
     let x64 = x as f64;
 
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120

--- a/src/math/tanh.rs
+++ b/src/math/tanh.rs
@@ -6,7 +6,7 @@ use super::expm1;
  */
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn tanh(mut x: f64) -> f64 {
+pub extern "C" fn tanh(mut x: f64) -> f64 {
     let mut uf: f64 = x;
     let mut ui: u64 = f64::to_bits(uf);
 

--- a/src/math/tanhf.rs
+++ b/src/math/tanhf.rs
@@ -2,7 +2,7 @@ use super::expm1f;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn tanhf(mut x: f32) -> f32 {
+pub extern "C" fn tanhf(mut x: f32) -> f32 {
     /* x = |x| */
     let mut ix = x.to_bits();
     let sign = (ix >> 31) != 0;

--- a/src/math/tgamma.rs
+++ b/src/math/tgamma.rs
@@ -130,7 +130,7 @@ fn s(x: f64) -> f64 {
     return num / den;
 }
 
-pub fn tgamma(mut x: f64) -> f64 {
+pub extern "C" fn tgamma(mut x: f64) -> f64 {
     let u: u64 = x.to_bits();
     let absx: f64;
     let mut y: f64;

--- a/src/math/tgammaf.rs
+++ b/src/math/tgammaf.rs
@@ -1,5 +1,5 @@
 use super::tgamma;
 
-pub fn tgammaf(x: f32) -> f32 {
+pub extern "C" fn tgammaf(x: f32) -> f32 {
     tgamma(x as f64) as f32
 }

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -2,7 +2,7 @@ use core::f64;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn trunc(x: f64) -> f64 {
+pub extern "C" fn trunc(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f64.trunc` native instruction, so we can leverage this for both code size
     // and speed.

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -2,7 +2,7 @@ use core::f32;
 
 #[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
-pub fn truncf(x: f32) -> f32 {
+pub extern "C" fn truncf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized
     // `f32.trunc` native instruction, so we can leverage this for both code size
     // and speed.


### PR DESCRIPTION
This PR gives all public APIs the `nounwind` LLVM attribute by making them `extern "C"`. Note that `extern "C"` only changes the "call ABI" of the functions, it does not change name mangling. A different attribute, like `#[no_mangle]`, would be required change name mangling to C name mangling, _but that is not done here_.

For all types that this library uses, the call ABI of the Rust and the C calling convention is the same, so this PR does not change that either.