### PR TITLE
Remove most `#[inline]` annotations

### DIFF
--- a/src/math/acos.rs
+++ b/src/math/acos.rs
@@ -48,7 +48,6 @@ const QS2: f64 = 2.02094576023350569471e+00; /* 0x40002AE5, 0x9C598AC8 */
 const QS3: f64 = -6.88283971605453293030e-01; /* 0xBFE6066C, 0x1B8D0159 */
 const QS4: f64 = 7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 
-#[inline]
 fn r(z: f64) -> f64 {
     let p: f64 = z * (PS0 + z * (PS1 + z * (PS2 + z * (PS3 + z * (PS4 + z * PS5)))));
     let q: f64 = 1.0 + z * (QS1 + z * (QS2 + z * (QS3 + z * QS4)));
@@ -60,7 +59,6 @@ fn r(z: f64) -> f64 {
 /// Computes the inverse cosine (arc cosine) of the input value.
 /// Arguments must be in the range -1 to 1.
 /// Returns values in radians, in the range of 0 to pi.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn acos(x: f64) -> f64 {
     let x1p_120f = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ -120

--- a/src/math/acosf.rs
+++ b/src/math/acosf.rs
@@ -22,7 +22,6 @@ const P_S1: f32 = -4.2743422091e-02;
 const P_S2: f32 = -8.6563630030e-03;
 const Q_S1: f32 = -7.0662963390e-01;
 
-#[inline]
 fn r(z: f32) -> f32 {
     let p = z * (P_S0 + z * (P_S1 + z * P_S2));
     let q = 1. + z * Q_S1;
@@ -34,7 +33,6 @@ fn r(z: f32) -> f32 {
 /// Computes the inverse cosine (arc cosine) of the input value.
 /// Arguments must be in the range -1 to 1.
 /// Returns values in radians, in the range of 0 to pi.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn acosf(x: f32) -> f32 {
     let x1p_120 = f32::from_bits(0x03800000); // 0x1p-120 === 2 ^ (-120)

--- a/src/math/asin.rs
+++ b/src/math/asin.rs
@@ -55,7 +55,6 @@ const Q_S2: f64 = 2.02094576023350569471e+00; /* 0x40002AE5, 0x9C598AC8 */
 const Q_S3: f64 = -6.88283971605453293030e-01; /* 0xBFE6066C, 0x1B8D0159 */
 const Q_S4: f64 = 7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 
-#[inline]
 fn comp_r(z: f64) -> f64 {
     let p = z * (P_S0 + z * (P_S1 + z * (P_S2 + z * (P_S3 + z * (P_S4 + z * P_S5)))));
     let q = 1.0 + z * (Q_S1 + z * (Q_S2 + z * (Q_S3 + z * Q_S4)));
@@ -67,7 +66,6 @@ fn comp_r(z: f64) -> f64 {
 /// Computes the inverse sine (arc sine) of the argument `x`.
 /// Arguments to asin must be in the range -1 to 1.
 /// Returns values in radians, in the range of -pi/2 to pi/2.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn asin(mut x: f64) -> f64 {
     let z: f64;

--- a/src/math/asinf.rs
+++ b/src/math/asinf.rs
@@ -24,7 +24,6 @@ const P_S1: f32 = -4.2743422091e-02;
 const P_S2: f32 = -8.6563630030e-03;
 const Q_S1: f32 = -7.0662963390e-01;
 
-#[inline]
 fn r(z: f32) -> f32 {
     let p = z * (P_S0 + z * (P_S1 + z * P_S2));
     let q = 1. + z * Q_S1;
@@ -36,7 +35,6 @@ fn r(z: f32) -> f32 {
 /// Computes the inverse sine (arc sine) of the argument `x`.
 /// Arguments to asin must be in the range -1 to 1.
 /// Returns values in radians, in the range of -pi/2 to pi/2.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn asinf(mut x: f32) -> f32 {
     let x1p_120 = f64::from_bits(0x3870000000000000); // 0x1p-120 === 2 ^ (-120)

--- a/src/math/atan.rs
+++ b/src/math/atan.rs
@@ -64,7 +64,6 @@ const AT: [f64; 11] = [
 ///
 /// Computes the inverse tangent (arc tangent) of the input value.
 /// Returns a value in radians, in the range of -pi/2 to pi/2.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atan(x: f64) -> f64 {
     let mut x = x;

--- a/src/math/atan2.rs
+++ b/src/math/atan2.rs
@@ -48,7 +48,6 @@ const PI_LO: f64 = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
 /// Computes the inverse tangent (arc tangent) of `y/x`.
 /// Produces the correct result even for angles near pi/2 or -pi/2 (that is, when `x` is near 0).
 /// Returns a value in radians, in the range of -pi to pi.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atan2(y: f64, x: f64) -> f64 {
     if x.is_nan() || y.is_nan() {

--- a/src/math/atan2f.rs
+++ b/src/math/atan2f.rs
@@ -24,7 +24,6 @@ const PI_LO: f32 = -8.7422776573e-08; /* 0xb3bbbd2e */
 /// Computes the inverse tangent (arc tangent) of `y/x`.
 /// Produces the correct result even for angles near pi/2 or -pi/2 (that is, when `x` is near 0).
 /// Returns a value in radians, in the range of -pi to pi.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atan2f(y: f32, x: f32) -> f32 {
     if x.is_nan() || y.is_nan() {

--- a/src/math/atanf.rs
+++ b/src/math/atanf.rs
@@ -41,7 +41,6 @@ const A_T: [f32; 5] = [
 ///
 /// Computes the inverse tangent (arc tangent) of the input value.
 /// Returns a value in radians, in the range of -pi/2 to pi/2.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn atanf(mut x: f32) -> f32 {
     let x1p_120 = f32::from_bits(0x03800000); // 0x1p-120 === 2 ^ (-120)

--- a/src/math/cbrt.rs
+++ b/src/math/cbrt.rs
@@ -30,7 +30,6 @@ const P4: f64 = 0.145996192886612446982; /* 0x3fc2b000, 0xd4e4edd7 */
 // Cube root (f64)
 ///
 /// Computes the cube root of the argument.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn cbrt(x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54

--- a/src/math/cbrtf.rs
+++ b/src/math/cbrtf.rs
@@ -25,7 +25,6 @@ const B2: u32 = 642849266; /* B2 = (127-127.0/3-24/3-0.03306235651)*2**23 */
 /// Cube root (f32)
 ///
 /// Computes the cube root of the argument.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn cbrtf(x: f32) -> f32 {
     let x1p24 = f32::from_bits(0x4b800000); // 0x1p24f === 2 ^ 24

--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -5,7 +5,6 @@ const TOINT: f64 = 1. / f64::EPSILON;
 /// Ceil (f64)
 ///
 /// Finds the nearest integer greater than or equal to `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ceil(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -3,7 +3,6 @@ use core::f32;
 /// Ceil (f32)
 ///
 /// Finds the nearest integer greater than or equal to `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ceilf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/cos.rs
+++ b/src/math/cos.rs
@@ -41,7 +41,6 @@ use super::{k_cos, k_sin, rem_pio2};
 // Accuracy:
 //      TRIG(x) returns trig(x) nearly rounded
 //
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn cos(x: f64) -> f64 {
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;

--- a/src/math/cosf.rs
+++ b/src/math/cosf.rs
@@ -24,7 +24,6 @@ const C2_PIO2: f64 = 2. * FRAC_PI_2; /* 0x400921FB, 0x54442D18 */
 const C3_PIO2: f64 = 3. * FRAC_PI_2; /* 0x4012D97C, 0x7F3321D2 */
 const C4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn cosf(x: f32) -> f32 {
     let x64 = x as f64;

--- a/src/math/cosh.rs
+++ b/src/math/cosh.rs
@@ -7,7 +7,6 @@ use super::k_expo2;
 /// Computes the hyperbolic cosine of the argument x.
 /// Is defined as `(exp(x) + exp(-x))/2`
 /// Angles are specified in radians.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn cosh(mut x: f64) -> f64 {
     /* |x| */

--- a/src/math/coshf.rs
+++ b/src/math/coshf.rs
@@ -7,7 +7,6 @@ use super::k_expo2f;
 /// Computes the hyperbolic cosine of the argument x.
 /// Is defined as `(exp(x) + exp(-x))/2`
 /// Angles are specified in radians.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn coshf(mut x: f32) -> f32 {
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120

--- a/src/math/exp.rs
+++ b/src/math/exp.rs
@@ -81,7 +81,6 @@ const P5: f64 = 4.13813679705723846039e-08; /* 0x3E663769, 0x72BEA4D0 */
 ///
 /// Calculate the exponential of `x`, that is, *e* raised to the power `x`
 /// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp(mut x: f64) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023

--- a/src/math/exp2.rs
+++ b/src/math/exp2.rs
@@ -322,7 +322,6 @@ static TBL: [u64; TBLSIZE * 2] = [
 /// Exponential, base 2 (f64)
 ///
 /// Calculate `2^x`, that is, 2 raised to the power `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp2(mut x: f64) -> f64 {
     let redux = f64::from_bits(0x4338000000000000) / TBLSIZE as f64;

--- a/src/math/exp2f.rs
+++ b/src/math/exp2f.rs
@@ -73,7 +73,6 @@ static EXP2FT: [u64; TBLSIZE] = [
 /// Exponential, base 2 (f32)
 ///
 /// Calculate `2^x`, that is, 2 raised to the power `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn exp2f(mut x: f32) -> f32 {
     let redux = f32::from_bits(0x4b400000) / TBLSIZE as f32;

--- a/src/math/expf.rs
+++ b/src/math/expf.rs
@@ -30,7 +30,6 @@ const P2: f32 = -2.7667332906e-3; /* -0xb55215.0p-32 */
 ///
 /// Calculate the exponential of `x`, that is, *e* raised to the power `x`
 /// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn expf(mut x: f32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127

--- a/src/math/expm1.rs
+++ b/src/math/expm1.rs
@@ -30,7 +30,6 @@ const Q5: f64 = -2.01099218183624371326e-07; /* BE8AFDB7 6E09C32D */
 /// system of logarithms, approximately 2.71828).
 /// The result is accurate even for small values of `x`,
 /// where using `exp(x)-1` would lose many significant digits.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn expm1(mut x: f64) -> f64 {
     let hi: f64;

--- a/src/math/expm1f.rs
+++ b/src/math/expm1f.rs
@@ -32,7 +32,6 @@ const Q2: f32 = 1.5807170421e-3; /*  0xcf3010.0p-33 */
 /// system of logarithms, approximately 2.71828).
 /// The result is accurate even for small values of `x`,
 /// where using `exp(x)-1` would lose many significant digits.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn expm1f(mut x: f32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127

--- a/src/math/expo2.rs
+++ b/src/math/expo2.rs
@@ -1,7 +1,6 @@
 use super::{combine_words, exp};
 
 /* exp(x)/2 for x >= log(DBL_MAX), slightly better than 0.5*exp(x/2)*exp(x/2) */
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn expo2(x: f64) -> f64 {
     /* k is such that k*ln2 has minimal relative error and x - kln2 > log(DBL_MIN) */

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -3,7 +3,6 @@ use core::u64;
 /// Absolute value (magnitude) (f64)
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fabs(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -1,7 +1,6 @@
 /// Absolute value (magnitude) (f32)
 /// Calculates the absolute value (magnitude) of the argument `x`,
 /// by direct manipulation of the bit representation of `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fabsf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/fdim.rs
+++ b/src/math/fdim.rs
@@ -8,7 +8,6 @@ use core::f64;
 /// * NAN	if either argument is NAN.
 ///
 /// A range error may occur.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fdim(x: f64, y: f64) -> f64 {
     if x.is_nan() {

--- a/src/math/fdimf.rs
+++ b/src/math/fdimf.rs
@@ -8,7 +8,6 @@ use core::f32;
 /// * NAN	if either argument is NAN.
 ///
 /// A range error may occur.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fdimf(x: f32, y: f32) -> f32 {
     if x.is_nan() {

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -5,7 +5,6 @@ const TOINT: f64 = 1. / f64::EPSILON;
 /// Floor (f64)
 ///
 /// Finds the nearest integer less than or equal to `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn floor(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -3,7 +3,6 @@ use core::f32;
 /// Floor (f32)
 ///
 /// Finds the nearest integer less than or equal to `x`.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn floorf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/fma.rs
+++ b/src/math/fma.rs
@@ -10,7 +10,6 @@ struct Num {
     sign: i32,
 }
 
-#[inline]
 fn normalize(x: f64) -> Num {
     let x1p63: f64 = f64::from_bits(0x43e0000000000000); // 0x1p63 === 2 ^ 63
 
@@ -30,7 +29,6 @@ fn normalize(x: f64) -> Num {
     Num { m: ix, e, sign }
 }
 
-#[inline]
 fn mul(x: u64, y: u64) -> (u64, u64) {
     let t1: u64;
     let t2: u64;
@@ -53,7 +51,6 @@ fn mul(x: u64, y: u64) -> (u64, u64) {
 /// Computes `(x*y)+z`, rounded as one ternary operation:
 /// Computes the value (as if) to infinite precision and rounds once to the result format,
 /// according to the rounding mode characterized by the value of FLT_ROUNDS.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fma(x: f64, y: f64, z: f64) -> f64 {
     let x1p63: f64 = f64::from_bits(0x43e0000000000000); // 0x1p63 === 2 ^ 63

--- a/src/math/fmaf.rs
+++ b/src/math/fmaf.rs
@@ -46,7 +46,6 @@ use super::fenv::{
 /// Computes `(x*y)+z`, rounded as one ternary operation:
 /// Computes the value (as if) to infinite precision and rounds once to the result format,
 /// according to the rounding mode characterized by the value of FLT_ROUNDS.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmaf(x: f32, y: f32, mut z: f32) -> f32 {
     let xy: f64;

--- a/src/math/fmax.rs
+++ b/src/math/fmax.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmax(x: f64, y: f64) -> f64 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the

--- a/src/math/fmaxf.rs
+++ b/src/math/fmaxf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmaxf(x: f32, y: f32) -> f32 {
     // IEEE754 says: maxNum(x, y) is the canonicalized number y if x < y, x if y < x, the

--- a/src/math/fmin.rs
+++ b/src/math/fmin.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmin(x: f64, y: f64) -> f64 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the

--- a/src/math/fminf.rs
+++ b/src/math/fminf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fminf(x: f32, y: f32) -> f32 {
     // IEEE754 says: minNum(x, y) is the canonicalized number x if x < y, y if y < x, the

--- a/src/math/fmod.rs
+++ b/src/math/fmod.rs
@@ -1,6 +1,5 @@
 use core::u64;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmod(x: f64, y: f64) -> f64 {
     let mut uxi = x.to_bits();

--- a/src/math/fmodf.rs
+++ b/src/math/fmodf.rs
@@ -1,7 +1,6 @@
 use core::f32;
 use core::u32;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn fmodf(x: f32, y: f32) -> f32 {
     let mut uxi = x.to_bits();

--- a/src/math/hypot.rs
+++ b/src/math/hypot.rs
@@ -4,7 +4,6 @@ use super::sqrt;
 
 const SPLIT: f64 = 134217728. + 1.; // 0x1p27 + 1 === (2 ^ 27) + 1
 
-#[inline]
 fn sq(x: f64) -> (f64, f64) {
     let xh: f64;
     let xl: f64;
@@ -18,7 +17,6 @@ fn sq(x: f64) -> (f64, f64) {
     (hi, lo)
 }
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn hypot(mut x: f64, mut y: f64) -> f64 {
     let x1p700 = f64::from_bits(0x6bb0000000000000); // 0x1p700 === 2 ^ 700

--- a/src/math/hypotf.rs
+++ b/src/math/hypotf.rs
@@ -2,7 +2,6 @@ use core::f32;
 
 use super::sqrtf;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn hypotf(mut x: f32, mut y: f32) -> f32 {
     let x1p90 = f32::from_bits(0x6c800000); // 0x1p90f === 2 ^ 90

--- a/src/math/k_cos.rs
+++ b/src/math/k_cos.rs
@@ -51,7 +51,6 @@ const C6: f64 = -1.13596475577881948265e-11; /* 0xBDA8FAE9, 0xBE8838D4 */
 //         expression for cos().  Retention happens in all cases tested
 //         under FreeBSD, so don't pessimize things by forcibly clipping
 //         any extra precision in w.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_cos(x: f64, y: f64) -> f64 {
     let z = x * x;

--- a/src/math/k_cosf.rs
+++ b/src/math/k_cosf.rs
@@ -20,7 +20,6 @@ const C1: f64 = 0.0416666233237390631894; /*  0x155553e1053a42.0p-57 */
 const C2: f64 = -0.00138867637746099294692; /* -0x16c087e80f1e27.0p-62 */
 const C3: f64 = 0.0000243904487962774090654; /*  0x199342e0ee5069.0p-68 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_cosf(x: f64) -> f32 {
     let z = x * x;

--- a/src/math/k_expo2.rs
+++ b/src/math/k_expo2.rs
@@ -4,7 +4,6 @@ use super::exp;
 const K: i32 = 2043;
 
 /* expf(x)/2 for x >= log(FLT_MAX), slightly better than 0.5f*expf(x/2)*expf(x/2) */
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_expo2(x: f64) -> f64 {
     let k_ln2 = f64::from_bits(0x40962066151add8b);

--- a/src/math/k_expo2f.rs
+++ b/src/math/k_expo2f.rs
@@ -4,7 +4,6 @@ use super::expf;
 const K: i32 = 235;
 
 /* expf(x)/2 for x >= log(FLT_MAX), slightly better than 0.5f*expf(x/2)*expf(x/2) */
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_expo2f(x: f32) -> f32 {
     let k_ln2 = f32::from_bits(0x4322e3bc);

--- a/src/math/k_sin.rs
+++ b/src/math/k_sin.rs
@@ -43,7 +43,6 @@ const S6: f64 = 1.58969099521155010221e-10; /* 0x3DE5D93A, 0x5ACFD57C */
 //              r = x *(S2+x *(S3+x *(S4+x *(S5+x *S6))))
 //         then                   3    2
 //              sin(x) = x + (S1*x + (x *(r-y/2)+y))
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_sin(x: f64, y: f64, iy: i32) -> f64 {
     let z = x * x;

--- a/src/math/k_sinf.rs
+++ b/src/math/k_sinf.rs
@@ -20,7 +20,6 @@ const S2: f64 = 0.0083333293858894631756; /*  0x111110896efbb2.0p-59 */
 const S3: f64 = -0.000198393348360966317347; /* -0x1a00f9e2cae774.0p-65 */
 const S4: f64 = 0.0000027183114939898219064; /*  0x16cd878c3b46a7.0p-71 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_sinf(x: f64) -> f32 {
     let z = x * x;

--- a/src/math/k_tan.rs
+++ b/src/math/k_tan.rs
@@ -58,7 +58,6 @@ static T: [f64; 13] = [
 const PIO4: f64 = 7.85398163397448278999e-01; /* 3FE921FB, 54442D18 */
 const PIO4_LO: f64 = 3.06161699786838301793e-17; /* 3C81A626, 33145C07 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_tan(mut x: f64, mut y: f64, odd: i32) -> f64 {
     let hx = (f64::to_bits(x) >> 32) as u32;
@@ -101,7 +100,6 @@ pub(crate) fn k_tan(mut x: f64, mut y: f64, odd: i32) -> f64 {
     a0 + a * (1.0 + a0 * w0 + a0 * v)
 }
 
-#[inline]
 fn zero_low_word(x: f64) -> f64 {
     f64::from_bits(f64::to_bits(x) & 0xFFFF_FFFF_0000_0000)
 }

--- a/src/math/k_tanf.rs
+++ b/src/math/k_tanf.rs
@@ -19,7 +19,6 @@ const T: [f64; 6] = [
     0.00946564784943673166728, /* 0x1362b9bf971bcd.0p-59 */
 ];
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn k_tanf(x: f64, odd: bool) -> f32 {
     let z = x * x;

--- a/src/math/ldexp.rs
+++ b/src/math/ldexp.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ldexp(x: f64, n: i32) -> f64 {
     super::scalbn(x, n)

--- a/src/math/ldexpf.rs
+++ b/src/math/ldexpf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn ldexpf(x: f32, n: i32) -> f32 {
     super::scalbnf(x, n)

--- a/src/math/log.rs
+++ b/src/math/log.rs
@@ -70,7 +70,6 @@ const LG5: f64 = 1.818357216161805012e-01; /* 3FC74664 96CB03DE */
 const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54

--- a/src/math/log10.rs
+++ b/src/math/log10.rs
@@ -31,7 +31,6 @@ const LG5: f64 = 1.818357216161805012e-01; /* 3FC74664 96CB03DE */
 const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log10(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54

--- a/src/math/log10f.rs
+++ b/src/math/log10f.rs
@@ -25,7 +25,6 @@ const LG2: f32 = 0.40000972152; /* 0xccce13.0p-25 */
 const LG3: f32 = 0.28498786688; /* 0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log10f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25

--- a/src/math/log1p.rs
+++ b/src/math/log1p.rs
@@ -65,7 +65,6 @@ const LG5: f64 = 1.818357216161805012e-01; /* 3FC74664 96CB03DE */
 const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log1p(x: f64) -> f64 {
     let mut ui: u64 = x.to_bits();

--- a/src/math/log1pf.rs
+++ b/src/math/log1pf.rs
@@ -20,7 +20,6 @@ const LG2: f32 = 0.40000972152; /* 0xccce13.0p-25 */
 const LG3: f32 = 0.28498786688; /* 0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log1pf(x: f32) -> f32 {
     let mut ui: u32 = x.to_bits();

--- a/src/math/log2.rs
+++ b/src/math/log2.rs
@@ -29,7 +29,6 @@ const LG5: f64 = 1.818357216161805012e-01; /* 3FC74664 96CB03DE */
 const LG6: f64 = 1.531383769920937332e-01; /* 3FC39A09 D078C69F */
 const LG7: f64 = 1.479819860511658591e-01; /* 3FC2F112 DF3E5244 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log2(mut x: f64) -> f64 {
     let x1p54 = f64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54

--- a/src/math/log2f.rs
+++ b/src/math/log2f.rs
@@ -23,7 +23,6 @@ const LG2: f32 = 0.40000972152; /* 0xccce13.0p-25 */
 const LG3: f32 = 0.28498786688; /* 0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /* 0xf89e26.0p-26 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn log2f(mut x: f32) -> f32 {
     let x1p25f = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25

--- a/src/math/logf.rs
+++ b/src/math/logf.rs
@@ -21,7 +21,6 @@ const LG2: f32 = 0.40000972152; /*  0xccce13.0p-25 */
 const LG3: f32 = 0.28498786688; /*  0x91e9ee.0p-25 */
 const LG4: f32 = 0.24279078841; /*  0xf89e26.0p-26 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn logf(mut x: f32) -> f32 {
     let x1p25 = f32::from_bits(0x4c000000); // 0x1p25f === 2 ^ 25

--- a/src/math/nextafter.rs
+++ b/src/math/nextafter.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn nextafter(x: f64, y: f64) -> f64 {
     if x.is_nan() || y.is_nan() {

--- a/src/math/nextafterf.rs
+++ b/src/math/nextafterf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn nextafterf(x: f32, y: f32) -> f32 {
     if x.is_nan() || y.is_nan() {

--- a/src/math/pow.rs
+++ b/src/math/pow.rs
@@ -89,7 +89,6 @@ const IVLN2: f64 = 1.44269504088896338700e+00; /* 0x3ff71547_652b82fe =1/ln2 */
 const IVLN2_H: f64 = 1.44269502162933349609e+00; /* 0x3ff71547_60000000 =24b 1/ln2*/
 const IVLN2_L: f64 = 1.92596299112661746887e-08; /* 0x3e54ae0b_f85ddf44 =1/ln2 tail*/
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn pow(x: f64, y: f64) -> f64 {
     let t1: f64;

--- a/src/math/powf.rs
+++ b/src/math/powf.rs
@@ -43,7 +43,6 @@ const IVLN2: f32 = 1.4426950216e+00;
 const IVLN2_H: f32 = 1.4426879883e+00;
 const IVLN2_L: f32 = 7.0526075433e-06;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn powf(x: f32, y: f32) -> f32 {
     let mut z: f32;

--- a/src/math/rem_pio2.rs
+++ b/src/math/rem_pio2.rs
@@ -41,7 +41,6 @@ const PIO2_3T: f64 = 8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
 // use rem_pio2_large() for large x
 //
 // caller must handle the case when reduction is not needed: |x| ~<= pi/4 */
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
     let x1p24 = f64::from_bits(0x4170000000000000);
@@ -49,7 +48,6 @@ pub(crate) fn rem_pio2(x: f64) -> (i32, f64, f64) {
     let sign = (f64::to_bits(x) >> 63) as i32;
     let ix = (f64::to_bits(x) >> 32) as u32 & 0x7fffffff;
 
-    #[inline]
     fn medium(x: f64, ix: u32) -> (i32, f64, f64) {
         /* rint(x/(pi/2)), Assume round-to-nearest. */
         let f_n = x as f64 * INV_PIO2 + TO_INT - TO_INT;

--- a/src/math/rem_pio2_large.rs
+++ b/src/math/rem_pio2_large.rs
@@ -222,7 +222,6 @@ const PIO2: [f64; 8] = [
 /// skip the part of the product that are known to be a huge integer (
 /// more accurately, = 0 mod 8 ). Thus the number of operations are
 /// independent of the exponent of the input.
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn rem_pio2_large(x: &[f64], y: &mut [f64], e0: i32, prec: usize) -> i32 {
     let x1p24 = f64::from_bits(0x4170000000000000); // 0x1p24 === 2 ^ 24

--- a/src/math/rem_pio2f.rs
+++ b/src/math/rem_pio2f.rs
@@ -31,7 +31,6 @@ const PIO2_1T: f64 = 1.58932547735281966916e-08; /* 0x3E5110b4, 0x611A6263 */
 ///
 /// use double precision for everything except passing x
 /// use __rem_pio2_large() for large x
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub(crate) fn rem_pio2f(x: f32) -> (i32, f64) {
     let x64 = x as f64;

--- a/src/math/remainder.rs
+++ b/src/math/remainder.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remainder(x: f64, y: f64) -> f64 {
     let (result, _) = super::remquo(x, y);

--- a/src/math/remainderf.rs
+++ b/src/math/remainderf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remainderf(x: f32, y: f32) -> f32 {
     let (result, _) = super::remquof(x, y);

--- a/src/math/remquo.rs
+++ b/src/math/remquo.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remquo(mut x: f64, mut y: f64) -> (f64, i32) {
     let ux: u64 = x.to_bits();
     let mut uy: u64 = y.to_bits();

--- a/src/math/remquof.rs
+++ b/src/math/remquof.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn remquof(mut x: f32, mut y: f32) -> (f32, i32) {
     let ux: u32 = x.to_bits();
     let mut uy: u32 = y.to_bits();

--- a/src/math/round.rs
+++ b/src/math/round.rs
@@ -2,7 +2,6 @@ use core::f64;
 
 const TOINT: f64 = 1.0 / f64::EPSILON;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn round(mut x: f64) -> f64 {
     let i = x.to_bits();

--- a/src/math/roundf.rs
+++ b/src/math/roundf.rs
@@ -2,7 +2,6 @@ use core::f32;
 
 const TOINT: f32 = 1.0 / f32::EPSILON;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn roundf(mut x: f32) -> f32 {
     let i = x.to_bits();

--- a/src/math/scalbn.rs
+++ b/src/math/scalbn.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn scalbn(x: f64, mut n: i32) -> f64 {
     let x1p1023 = f64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023

--- a/src/math/scalbnf.rs
+++ b/src/math/scalbnf.rs
@@ -1,4 +1,3 @@
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn scalbnf(mut x: f32, mut n: i32) -> f32 {
     let x1p127 = f32::from_bits(0x7f000000); // 0x1p127f === 2 ^ 127

--- a/src/math/sin.rs
+++ b/src/math/sin.rs
@@ -40,7 +40,6 @@ use super::{k_cos, k_sin, rem_pio2};
 //
 // Accuracy:
 //      TRIG(x) returns trig(x) nearly rounded
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sin(x: f64) -> f64 {
     let x1p120 = f64::from_bits(0x4770000000000000); // 0x1p120f === 2 ^ 120

--- a/src/math/sinf.rs
+++ b/src/math/sinf.rs
@@ -24,7 +24,6 @@ const S2_PIO2: f64 = 2. * FRAC_PI_2; /* 0x400921FB, 0x54442D18 */
 const S3_PIO2: f64 = 3. * FRAC_PI_2; /* 0x4012D97C, 0x7F3321D2 */
 const S4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sinf(x: f32) -> f32 {
     let x64 = x as f64;

--- a/src/math/sinh.rs
+++ b/src/math/sinh.rs
@@ -4,7 +4,6 @@ use super::{expm1, expo2};
 //         = (exp(x)-1 + (exp(x)-1)/exp(x))/2
 //         = x + x^3/6 + o(x^5)
 //
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sinh(x: f64) -> f64 {
     // union {double f; uint64_t i;} u = {.f = x};

--- a/src/math/sinhf.rs
+++ b/src/math/sinhf.rs
@@ -1,7 +1,6 @@
 use super::expm1f;
 use super::k_expo2f;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sinhf(x: f32) -> f32 {
     let mut h = 0.5f32;

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -81,7 +81,6 @@ use core::num::Wrapping;
 
 const TINY: f64 = 1.0e-300;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sqrt(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -15,7 +15,6 @@
 
 const TINY: f32 = 1.0e-30;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn sqrtf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/tan.rs
+++ b/src/math/tan.rs
@@ -39,7 +39,6 @@ use super::{k_tan, rem_pio2};
 //
 // Accuracy:
 //      TRIG(x) returns trig(x) nearly rounded
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tan(x: f64) -> f64 {
     let x1p120 = f32::from_bits(0x7b800000); // 0x1p120f === 2 ^ 120

--- a/src/math/tanf.rs
+++ b/src/math/tanf.rs
@@ -24,7 +24,6 @@ const T2_PIO2: f64 = 2. * FRAC_PI_2; /* 0x400921FB, 0x54442D18 */
 const T3_PIO2: f64 = 3. * FRAC_PI_2; /* 0x4012D97C, 0x7F3321D2 */
 const T4_PIO2: f64 = 4. * FRAC_PI_2; /* 0x401921FB, 0x54442D18 */
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tanf(x: f32) -> f32 {
     let x64 = x as f64;

--- a/src/math/tanh.rs
+++ b/src/math/tanh.rs
@@ -4,7 +4,6 @@ use super::expm1;
  *         = (exp(2*x) - 1)/(exp(2*x) - 1 + 2)
  *         = (1 - exp(-2*x))/(exp(-2*x) - 1 + 2)
  */
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tanh(mut x: f64) -> f64 {
     let mut uf: f64 = x;

--- a/src/math/tanhf.rs
+++ b/src/math/tanhf.rs
@@ -1,6 +1,5 @@
 use super::expm1f;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn tanhf(mut x: f32) -> f32 {
     /* x = |x| */

--- a/src/math/trunc.rs
+++ b/src/math/trunc.rs
@@ -1,6 +1,5 @@
 use core::f64;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn trunc(x: f64) -> f64 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized

--- a/src/math/truncf.rs
+++ b/src/math/truncf.rs
@@ -1,6 +1,5 @@
 use core::f32;
 
-#[inline]
 #[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
 pub fn truncf(x: f32) -> f32 {
     // On wasm32 we know that LLVM's intrinsic will compile to an optimized


### PR DESCRIPTION
These annotations fall into a few categories

* Some simply aren't needed since functions will always be in the same
  CGU anyway and are already candidates for inlining.
* Many are on massive functions which shouldn't be inlined across crates
  due to code size concerns.
* Others aren't necessary since calls to this crate are rarely inlined
  anyway (since it's lowered through LLVM).

If this crate is called directly and inlining is needed then LTO can
always be turned on, otherwise this will benefit downstream consumers by
avoiding re-codegen'ing so many functions.