### PR TITLE
slightly improve spec and sanity check coverage

### DIFF
--- a/src/math/ceil.rs
+++ b/src/math/ceil.rs
@@ -42,9 +42,22 @@ pub fn ceil(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use core::f64::*;
+
     #[test]
     fn sanity_check() {
-        assert_eq!(super::ceil(1.1), 2.0);
-        assert_eq!(super::ceil(2.9), 3.0);
+        assert_eq!(ceil(1.1), 2.0);
+        assert_eq!(ceil(2.9), 3.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/ceil
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: that the current rounding mode has no effect.
+        assert!(ceil(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(ceil(f), f);
+        }
     }
 }

--- a/src/math/ceilf.rs
+++ b/src/math/ceilf.rs
@@ -39,3 +39,25 @@ pub fn ceilf(x: f32) -> f32 {
     }
     f32::from_bits(ui)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f32::*;
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(ceilf(1.1), 2.0);
+        assert_eq!(ceilf(2.9), 3.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/ceil
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: that the current rounding mode has no effect.
+        assert!(ceilf(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(ceilf(f), f);
+        }
+    }
+}

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -23,8 +23,8 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-      assert_eq!(fabs(-1.0), 1.0);
-      assert_eq!(fabs(2.8), 2.8);
+        assert_eq!(fabs(-1.0), 1.0);
+        assert_eq!(fabs(2.8), 2.8);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs

--- a/src/math/fabs.rs
+++ b/src/math/fabs.rs
@@ -15,3 +15,27 @@ pub fn fabs(x: f64) -> f64 {
     }
     f64::from_bits(x.to_bits() & (u64::MAX / 2))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f64::*;
+
+    #[test]
+    fn sanity_check() {
+      assert_eq!(fabs(-1.0), 1.0);
+      assert_eq!(fabs(2.8), 2.8);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs
+    #[test]
+    fn spec_tests() {
+        assert!(fabs(NAN).is_nan());
+        for f in [0.0, -0.0].iter().copied() {
+            assert_eq!(fabs(f), 0.0);
+        }
+        for f in [INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(fabs(f), INFINITY);
+        }
+    }
+}

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -13,3 +13,27 @@ pub fn fabsf(x: f32) -> f32 {
     }
     f32::from_bits(x.to_bits() & 0x7fffffff)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f32::*;
+
+    #[test]
+    fn sanity_check() {
+      assert_eq!(fabsf(-1.0), 1.0);
+      assert_eq!(fabsf(2.8), 2.8);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs
+    #[test]
+    fn spec_tests() {
+        assert!(fabsf(NAN).is_nan());
+        for f in [0.0, -0.0].iter().copied() {
+            assert_eq!(fabsf(f), 0.0);
+        }
+        for f in [INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(fabsf(f), INFINITY);
+        }
+    }
+}

--- a/src/math/fabsf.rs
+++ b/src/math/fabsf.rs
@@ -21,8 +21,8 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-      assert_eq!(fabsf(-1.0), 1.0);
-      assert_eq!(fabsf(2.8), 2.8);
+        assert_eq!(fabsf(-1.0), 1.0);
+        assert_eq!(fabsf(2.8), 2.8);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/fabs

--- a/src/math/floor.rs
+++ b/src/math/floor.rs
@@ -38,3 +38,25 @@ pub fn floor(x: f64) -> f64 {
         x + y
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f64::*;
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(floor(1.1), 1.0);
+        assert_eq!(floor(2.9), 2.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/floor
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: that the current rounding mode has no effect.
+        assert!(floor(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(floor(f), f);
+        }
+    }
+}

--- a/src/math/floorf.rs
+++ b/src/math/floorf.rs
@@ -42,8 +42,23 @@ pub fn floorf(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use core::f32::*;
+
     #[test]
-    fn no_overflow() {
-        assert_eq!(super::floorf(0.5), 0.0);
+    fn sanity_check() {
+        assert_eq!(floorf(0.5), 0.0);
+        assert_eq!(floorf(1.1), 1.0);
+        assert_eq!(floorf(2.9), 2.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/floor
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: that the current rounding mode has no effect.
+        assert!(floorf(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY, NEG_INFINITY].iter().copied() {
+            assert_eq!(floorf(f), f);
+        }
     }
 }

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -37,7 +37,7 @@
  *      If (2) is false, then q   = q ; otherwise q   = q  + 2      .
  *                             i+1   i             i+1   i
  *
- *      With some algebric manipulation, it is not difficult to see
+ *      With some algebraic manipulation, it is not difficult to see
  *      that (2) is equivalent to
  *                             -(i+1)
  *                      s  +  2       <= y                      (3)
@@ -237,5 +237,28 @@ pub fn sqrt(x: f64) -> f64 {
         }
         ix0 += m << 20;
         f64::from_bits((ix0 as u64) << 32 | ix1.0 as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f64::*;
+
+    #[test]
+    fn sanity_check() {
+      assert_eq!(sqrt(100.0), 10.0);
+      assert_eq!(sqrt(4.0), 2.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/sqrt
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: FE_INVALID exception is raised if argument is negative.
+        assert!(sqrt(-1.0).is_nan());
+        assert!(sqrt(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY].iter().copied() {
+            assert_eq!(sqrt(f), f);
+        }
     }
 }

--- a/src/math/sqrt.rs
+++ b/src/math/sqrt.rs
@@ -247,8 +247,8 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-      assert_eq!(sqrt(100.0), 10.0);
-      assert_eq!(sqrt(4.0), 2.0);
+        assert_eq!(sqrt(100.0), 10.0);
+        assert_eq!(sqrt(4.0), 2.0);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/sqrt

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -135,8 +135,8 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-      assert_eq!(sqrtf(100.0), 10.0);
-      assert_eq!(sqrtf(4.0), 2.0);
+        assert_eq!(sqrtf(100.0), 10.0);
+        assert_eq!(sqrtf(4.0), 2.0);
     }
 
     /// The spec: https://en.cppreference.com/w/cpp/numeric/math/sqrt

--- a/src/math/sqrtf.rs
+++ b/src/math/sqrtf.rs
@@ -127,3 +127,26 @@ pub fn sqrtf(x: f32) -> f32 {
         f32::from_bits(ix as u32)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f32::*;
+
+    #[test]
+    fn sanity_check() {
+      assert_eq!(sqrtf(100.0), 10.0);
+      assert_eq!(sqrtf(4.0), 2.0);
+    }
+
+    /// The spec: https://en.cppreference.com/w/cpp/numeric/math/sqrt
+    #[test]
+    fn spec_tests() {
+        // Not Asserted: FE_INVALID exception is raised if argument is negative.
+        assert!(sqrtf(-1.0).is_nan());
+        assert!(sqrtf(NAN).is_nan());
+        for f in [0.0, -0.0, INFINITY].iter().copied() {
+            assert_eq!(sqrtf(f), f);
+        }
+    }
+}


### PR DESCRIPTION
Per the general desire to have better tests in the crate, this is just a small touch up to the functions that have been of interest lately.

Doing too many functions at once makes it hard to review, so we're keeping it to just eight functions: f32 and f64 versions of `sqrt`, `ceil`, `floor`, and `abs`.