### PR TITLE
Refresh the CI setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,15 @@ version = "0.2.0"
 edition = "2018"
 
 [features]
-# only used to run our test suite
-default = ['stable']
-stable = []
+default = []
+
+# This tells the compiler to assume that a Nightly toolchain is being used and
+# that it should activate any useful Nightly things accordingly.
+unstable = []
 
 # Generate tests which are random inputs and the outputs are calculated with
 # musl libc.
 musl-reference-tests = ['rand']
-
-# Used checked array indexing instead of unchecked array indexing in this
-# library.
-checked = []
 
 [workspace]
 members = [

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,6 @@ jobs:
         displayName: "Install rust wasm target"
       - script: cargo build --target wasm32-unknown-unknown
         displayName: "Build for wasm"
-      - script: cargo build --target wasm32-unknown-unknown --no-default-features
-        displayName: "Build for wasm (no default features)"
     variables:
       TOOLCHAIN: nightly
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -3,7 +3,7 @@
 set -ex
 TARGET=$1
 
-CMD="cargo test --all --no-default-features --target $TARGET"
+CMD="cargo test --all --target $TARGET"
 
 $CMD
 $CMD --release

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,11 +5,14 @@ TARGET=$1
 
 CMD="cargo test --all --target $TARGET"
 
+# stable by default
 $CMD
 $CMD --release
 
-$CMD --features 'stable'
-$CMD --release --features 'stable'
+# unstable with a feature
+$CMD --features 'unstable'
+$CMD --release --features 'unstable'
 
-$CMD --features 'stable checked musl-reference-tests'
-$CMD --release --features  'stable checked musl-reference-tests'
+# also run the reference tests
+$CMD --features 'unstable musl-reference-tests'
+$CMD --release --features 'unstable musl-reference-tests'

--- a/crates/libm-bench/Cargo.toml
+++ b/crates/libm-bench/Cargo.toml
@@ -12,4 +12,4 @@ paste = "0.1.5"
 
 [features]
 default = []
-stable = [ "libm/stable" ]
+unstable = [ "libm/unstable" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(warnings)]
 #![no_std]
 #![cfg_attr(
-    all(target_arch = "wasm32", not(feature = "stable")),
+    all(target_arch = "wasm32", feature = "unstable"),
     feature(core_intrinsics)
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,15 @@
     all(target_arch = "wasm32", feature = "unstable"),
     feature(core_intrinsics)
 )]
+#![allow(clippy::unreadable_literal)]
+#![allow(clippy::many_single_char_names)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::int_plus_one)]
+#![allow(clippy::deprecated_cfg_attr)]
+#![allow(clippy::mixed_case_hex_literals)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::eq_op)]
+#![allow(clippy::assign_op_pattern)]
 
 mod math;
 

--- a/src/math/lgamma_r.rs
+++ b/src/math/lgamma_r.rs
@@ -270,9 +270,9 @@ pub fn lgamma_r(mut x: f64) -> (f64, i32) {
                 p2 = 1.0 + y * (V1 + y * (V2 + y * (V3 + y * (V4 + y * V5))));
                 r += -0.5 * y + p1 / p2;
             }
-            #[cfg(feature = "checked")]
+            #[cfg(debug_assertions)]
             _ => unreachable!(),
-            #[cfg(not(feature = "checked"))]
+            #[cfg(not(debug_assertions))]
             _ => {}
         }
     } else if ix < 0x40200000 {

--- a/src/math/lgammaf_r.rs
+++ b/src/math/lgammaf_r.rs
@@ -205,9 +205,9 @@ pub fn lgammaf_r(mut x: f32) -> (f32, i32) {
                 p2 = 1.0 + y * (V1 + y * (V2 + y * (V3 + y * (V4 + y * V5))));
                 r += -0.5 * y + p1 / p2;
             }
-            #[cfg(feature = "checked")]
+            #[cfg(debug_assertions)]
             _ => unreachable!(),
-            #[cfg(not(feature = "checked"))]
+            #[cfg(not(debug_assertions))]
             _ => {}
         }
     } else if ix < 0x41000000 {

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -6,7 +6,7 @@ macro_rules! force_eval {
     };
 }
 
-#[cfg(not(feature = "checked"))]
+#[cfg(not(debug_assertions))]
 macro_rules! i {
     ($array:expr, $index:expr) => {
         unsafe { *$array.get_unchecked($index) }
@@ -36,7 +36,7 @@ macro_rules! i {
     };
 }
 
-#[cfg(feature = "checked")]
+#[cfg(debug_assertions)]
 macro_rules! i {
     ($array:expr, $index:expr) => {
         *$array.get($index).unwrap()
@@ -60,7 +60,7 @@ macro_rules! i {
 
 macro_rules! llvm_intrinsically_optimized {
     (#[cfg($($clause:tt)*)] $e:expr) => {
-        #[cfg(all(not(feature = "stable"), $($clause)*))]
+        #[cfg(all(feature = "unstable", $($clause)*))]
         {
             if true { // thwart the dead code lint
                 $e

--- a/src/math/rem_pio2_large.rs
+++ b/src/math/rem_pio2_large.rs
@@ -461,9 +461,9 @@ pub(crate) fn rem_pio2_large(x: &[f64], y: &mut [f64], e0: i32, prec: usize) -> 
                 i!(y, 2, =, -fw);
             }
         }
-        #[cfg(feature = "checked")]
+        #[cfg(debug_assertions)]
         _ => unreachable!(),
-        #[cfg(not(feature = "checked"))]
+        #[cfg(not(debug_assertions))]
         _ => {}
     }
     n & 7

--- a/src/math/sincos.rs
+++ b/src/math/sincos.rs
@@ -51,9 +51,9 @@ pub fn sincos(x: f64) -> (f64, f64) {
         1 => (c, -s),
         2 => (-s, -c),
         3 => (-c, s),
-        #[cfg(feature = "checked")]
+        #[cfg(debug_assertions)]
         _ => unreachable!(),
-        #[cfg(not(feature = "checked"))]
+        #[cfg(not(debug_assertions))]
         _ => (0.0, 1.0),
     }
 }

--- a/src/math/sincosf.rs
+++ b/src/math/sincosf.rs
@@ -115,9 +115,9 @@ pub fn sincosf(x: f32) -> (f32, f32) {
         1 => (c, -s),
         2 => (-s, -c),
         3 => (-c, s),
-        #[cfg(feature = "checked")]
+        #[cfg(debug_assertions)]
         _ => unreachable!(),
-        #[cfg(not(feature = "checked"))]
+        #[cfg(not(debug_assertions))]
         _ => (0.0, 1.0),
     }
 }


### PR DESCRIPTION
This is its own PR _just_ to fix the CI/features, we can do the other thing with sqrt separately once we're confident we have this part fully sorted out.

* Remove the `checked` feature, just use the `debug_assertions` flag that's already part of Rust
* Swap the `stable` feature when we want Stable to be an `unstable` feature when we want Nightly bonuses.
* There are no longer any default features. The crate should operate in a totally plain mode by default.
* Since `#![deny(warnings)]` has been in the `lib.rs` the whole time, and since my editor runs clippy on the source, I at least silenced all the clippy warnings that we definitely don't care about. There's a lot more to do on the clippy front, but that means doing little tiny changes to almost every single file, so we'll leave that out for now

---

I'm putting up this PR so people can look and I can start to see where the CI errors are, I really don't expect it to pass CI this first time through.